### PR TITLE
The arrays were recognized as JSON and then processed incorrectly.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,919 +1,1067 @@
 import {
-  ColumnType,
-  ColumnTypeEnum,
-  IsolationLevel,
-  SqlDriverAdapter,
-  SqlQuery,
-  SqlResultSet,
-  Transaction,
+	ColumnType,
+	ColumnTypeEnum,
+	IsolationLevel,
+	SqlDriverAdapter,
+	SqlQuery,
+	SqlResultSet,
+	Transaction,
 } from "@prisma/driver-adapter-utils";
 
 // Common interfaces
 interface BunSqlResult extends Array<any> {
-  count: number;
-  command: string;
-  lastInsertRowid: number | null;
-  affectedRows: number | null;
+	count: number;
+	command: string;
+	lastInsertRowid: number | null;
+	affectedRows: number | null;
 }
 
 interface BunSqlConnection {
-  (strings: TemplateStringsArray, ...values: any[]): Promise<BunSqlResult>;
-  close(): Promise<void>;
-  end(): Promise<void>;
-  begin(): Promise<BunSqlTransaction>;
-  transaction<T>(callback: (tx: BunSqlTransaction) => Promise<T>): Promise<T>;
-  reserve(): Promise<BunReservedSqlConnection>;
+	(strings: TemplateStringsArray, ...values: any[]): Promise<BunSqlResult>;
+	close(): Promise<void>;
+	end(): Promise<void>;
+	begin(): Promise<BunSqlTransaction>;
+	transaction<T>(callback: (tx: BunSqlTransaction) => Promise<T>): Promise<T>;
+	reserve(): Promise<BunReservedSqlConnection>;
 }
 
 interface BunSqlTransaction {
-  (strings: TemplateStringsArray, ...values: any[]): Promise<BunSqlResult>;
-  commit(): Promise<void>;
-  rollback(): Promise<void>;
+	(strings: TemplateStringsArray, ...values: any[]): Promise<BunSqlResult>;
+	commit(): Promise<void>;
+	rollback(): Promise<void>;
 }
 
 interface BunReservedSqlConnection {
-  (strings: TemplateStringsArray, ...values: any[]): Promise<BunSqlResult>;
-  release?: () => Promise<void> | void;
+	(strings: TemplateStringsArray, ...values: any[]): Promise<BunSqlResult>;
+	release?: () => Promise<void> | void;
 }
 
 // Configuration interfaces
 export interface BunPostgresConfig {
-  connectionString: string;
-  maxConnections?: number;
-  idleTimeout?: number;
-  ssl?: boolean | {
-    rejectUnauthorized?: boolean;
-    ca?: string;
-    cert?: string;
-    key?: string;
-  };
+	connectionString: string;
+	maxConnections?: number;
+	idleTimeout?: number;
+	ssl?:
+		| boolean
+		| {
+				rejectUnauthorized?: boolean;
+				ca?: string;
+				cert?: string;
+				key?: string;
+		  };
 }
 
 export interface BunMySQLConfig {
-  connectionString: string;
-  maxConnections?: number;
-  idleTimeout?: number;
-  ssl?: boolean | {
-    rejectUnauthorized?: boolean;
-    ca?: string;
-    cert?: string;
-    key?: string;
-  };
+	connectionString: string;
+	maxConnections?: number;
+	idleTimeout?: number;
+	ssl?:
+		| boolean
+		| {
+				rejectUnauthorized?: boolean;
+				ca?: string;
+				cert?: string;
+				key?: string;
+		  };
 }
 
 export interface BunSQLiteConfig {
-  filename: string;
-  maxConnections?: number;
-  readonly?: boolean;
-  create?: boolean;
+	filename: string;
+	maxConnections?: number;
+	readonly?: boolean;
+	create?: boolean;
 }
 
 // Cache for template strings to avoid repeated parsing
-const templateCache = new Map<string, { strings: TemplateStringsArray; paramCount: number; argOrder: number[] }>();
+const templateCache = new Map<
+	string,
+	{ strings: TemplateStringsArray; paramCount: number; argOrder: number[] }
+>();
 
 // Pre-compiled column type matchers for better performance
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 const DATETIME_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
-const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+const UUID_REGEX =
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 // Base adapter class with shared functionality
 abstract class BaseBunDriverAdapter implements SqlDriverAdapter {
-  abstract readonly provider: "postgres" | "mysql" | "sqlite";
-  abstract readonly adapterName: string;
-  
-  protected connection: BunSqlConnection | null = null;
-  protected connectionString: string;
-  protected maxConnections: number;
+	abstract readonly provider: "postgres" | "mysql" | "sqlite";
+	abstract readonly adapterName: string;
 
-  constructor(connectionString: string, maxConnections: number = 5) {
-    this.connectionString = connectionString;
-    this.maxConnections = maxConnections;
-  }
+	protected connection: BunSqlConnection | null = null;
+	protected connectionString: string;
+	protected maxConnections: number;
 
-  protected async getConnection(): Promise<BunSqlConnection> {
-    if (!this.connection) {
-      this.connection = await this.createConnection();
-    }
-    return this.connection;
-  }
+	constructor(connectionString: string, maxConnections: number = 5) {
+		this.connectionString = connectionString;
+		this.maxConnections = maxConnections;
+	}
 
-  protected abstract createConnection(): Promise<BunSqlConnection>;
+	protected async getConnection(): Promise<BunSqlConnection> {
+		if (!this.connection) {
+			this.connection = await this.createConnection();
+		}
+		return this.connection;
+	}
 
-  async dispose(): Promise<void> {
-    if (this.connection) {
-      await this.connection.end();
-      this.connection = null;
-    }
-    templateCache.clear();
-  }
+	protected abstract createConnection(): Promise<BunSqlConnection>;
 
-  async executeScript(script: string): Promise<void> {
-    const connection = await this.getConnection();
-    const statements = script.split(';').filter(stmt => stmt.trim());
-    
-    for (const statement of statements) {
-      if (statement.trim()) {
-        const strings = this.createTemplateStrings([statement.trim()]);
-        await connection(strings);
-      }
-    }
-  }
+	async dispose(): Promise<void> {
+		if (this.connection) {
+			await this.connection.end();
+			this.connection = null;
+		}
+		templateCache.clear();
+	}
 
-  async queryRaw(query: SqlQuery): Promise<SqlResultSet> {
-    const connection = await this.getConnection();
-    const result = await this.executeQueryOptimized(connection, query.sql, query.args || []);
-    
-    if (!Array.isArray(result) || result.length === 0) {
-      return { columnNames: [], columnTypes: [], rows: [] };
-    }
+	async executeScript(script: string): Promise<void> {
+		const connection = await this.getConnection();
+		const statements = script.split(";").filter((stmt) => stmt.trim());
 
-    const firstRow = result[0];
-    const columnNames = Object.keys(firstRow);
-    const columnCount = columnNames.length;
-    const rowCount = result.length;
-    
-    // Determine column types by scanning all rows to better detect JSON columns
-    const columnTypes = this.determineColumnTypes(result, columnNames);
-    const rows = new Array(rowCount);
-    
-    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-      const row = result[rowIndex];
-      const processedRow = new Array(columnCount);
-      
-      for (let colIndex = 0; colIndex < columnCount; colIndex++) {
-        const val = row[columnNames[colIndex]];
-        if (columnTypes[colIndex] === ColumnTypeEnum.Json) {
-          processedRow[colIndex] = this.ensureJsonString(val);
-        } else {
-          processedRow[colIndex] = this.serializeValueFast(val);
-        }
-      }
-      
-      rows[rowIndex] = processedRow;
-    }
-    
-    return { columnNames, columnTypes, rows };
-  }
+		for (const statement of statements) {
+			if (statement.trim()) {
+				const strings = this.createTemplateStrings([statement.trim()]);
+				await connection(strings);
+			}
+		}
+	}
 
-  async executeRaw(query: SqlQuery): Promise<number> {
-    const connection = await this.getConnection();
-    try {
-      const result = await this.executeQueryOptimized(connection, query.sql, query.args || []);
-      return result.affectedRows || result.count || 0;
-    } catch (error) {
-      throw new Error(error instanceof Error ? error.message : String(error));
-    }
-  }
+	async queryRaw(query: SqlQuery): Promise<SqlResultSet> {
+		const connection = await this.getConnection();
+		const result = await this.executeQueryOptimized(
+			connection,
+			query.sql,
+			query.args || [],
+		);
 
-  protected executeQueryOptimized(connection: BunSqlConnection, sql: string, args: any[]): Promise<BunSqlResult> {
-    if (args.length === 0) {
-      const strings = this.createTemplateStrings([sql]);
-      return connection(strings);
-    }
-    
-    const cacheKey = sql;
-    let cached = templateCache.get(cacheKey);
-    
-    if ((!cached || cached.paramCount !== args.length) && this.hasParameterPlaceholders(sql)) {
-      const templateSql = this.convertParameterPlaceholders(sql, args.length);
-      const parts = templateSql.split(/\$\{\d+\}/);
-      const strings = this.createTemplateStrings(parts);
-      const argOrder: number[] = [];
-      const re = /\$\{(\d+)\}/g;
-      let m: RegExpExecArray | null;
-      while ((m = re.exec(templateSql)) !== null) {
-        argOrder.push(Number(m[1]));
-      }
-      cached = { strings, paramCount: args.length, argOrder };
-      templateCache.set(cacheKey, cached);
-    }
-    
-    if (cached) {
-      const expanded = cached.argOrder?.length ? cached.argOrder.map((i) => args[i]) : args;
-      const finalArgs = this.provider === 'postgres' ? this.coerceArgsForPostgres(expanded) : expanded;
-      return connection(cached.strings, ...finalArgs);
-    }
-    
-    const strings = this.createTemplateStrings([sql]);
-    return connection(strings);
-  }
+		if (!Array.isArray(result) || result.length === 0) {
+			return { columnNames: [], columnTypes: [], rows: [] };
+		}
 
-  protected abstract hasParameterPlaceholders(sql: string): boolean;
-  protected abstract convertParameterPlaceholders(sql: string, paramCount: number): string;
+		const firstRow = result[0];
+		const columnNames = Object.keys(firstRow);
+		const columnCount = columnNames.length;
+		const rowCount = result.length;
 
-  protected createTemplateStrings(parts: string[]): TemplateStringsArray {
-    if (parts.length === 1) {
-      parts = [...parts, ''];
-    }
-    return Object.assign(parts, { raw: parts }) as TemplateStringsArray;
-  }
+		// Determine column types by scanning all rows to better detect JSON columns
+		const columnTypes = this.determineColumnTypes(result, columnNames);
+		const rows = new Array(rowCount);
 
-  // Convert primitive JS arrays to a Postgres array literal string for array-typed columns.
-  // Leaves complex/object arrays untouched to avoid interfering with JSON payloads.
-  protected coerceArgsForPostgres(args: any[]): any[] {
-    const toPgArrayLiteral = (arr: any[]): string => {
-      const encodeItem = (v: any): string => {
-        if (v === null || v === undefined) return 'NULL';
-        switch (typeof v) {
-          case 'number':
-            return Number.isFinite(v) ? String(v) : 'NULL';
-          case 'boolean':
-            return v ? 'true' : 'false';
-          case 'string': {
-            const s = v.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-            return `"${s}"`;
-          }
-          default: {
-            try {
-              const s = JSON.stringify(v);
-              const e = s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-              return `"${e}"`;
-            } catch {
-              return 'NULL';
-            }
-          }
-        }
-      };
-      return `{${arr.map(encodeItem).join(',')}}`;
-    };
+		for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+			const row = result[rowIndex];
+			const processedRow = new Array(columnCount);
 
-    const isPrimitiveArray = (a: any[]): boolean =>
-      Array.isArray(a) && a.every((v) => v === null || ['string', 'number', 'boolean'].includes(typeof v));
+			for (let colIndex = 0; colIndex < columnCount; colIndex++) {
+				const val = row[columnNames[colIndex]];
+				if (columnTypes[colIndex] === ColumnTypeEnum.Json) {
+					processedRow[colIndex] = this.ensureJsonString(val);
+				} else {
+					processedRow[colIndex] = this.serializeValueFast(val);
+				}
+			}
 
-    return args.map((v) => (Array.isArray(v) && isPrimitiveArray(v) ? toPgArrayLiteral(v) : v));
-  }
+			rows[rowIndex] = processedRow;
+		}
 
-  // Normalize and encode credentials in connection string to avoid URI errors
-  protected normalizeConnectionString(input: string): string {
-    const raw = String(input ?? "").trim();
-    if (!raw) return raw;
+		return { columnNames, columnTypes, rows };
+	}
 
-    // Fast path: try URL parser first and re-encode userinfo
-    try {
-      const parsed = new URL(raw);
-      const scheme = parsed.protocol.replace(':', '');
-      if (['postgres', 'postgresql', 'mysql', 'mysqls', 'sqlite', 'file'].includes(scheme)) {
-        // Avoid double-encoding: decode valid %HH triplets first, then encode
-        const decodeTriplets = (s: string) => s.replace(/%[0-9a-fA-F]{2}/g, (m) => {
-          try { return decodeURIComponent(m); } catch { return m; }
-        });
-        if (parsed.username) parsed.username = encodeURIComponent(decodeTriplets(parsed.username));
-        if (parsed.password) parsed.password = encodeURIComponent(decodeTriplets(parsed.password));
-        return parsed.toString();
-      }
-      return raw;
-    } catch {}
+	async executeRaw(query: SqlQuery): Promise<number> {
+		const connection = await this.getConnection();
+		try {
+			const result = await this.executeQueryOptimized(
+				connection,
+				query.sql,
+				query.args || [],
+			);
+			return result.affectedRows || result.count || 0;
+		} catch (error) {
+			throw new Error(error instanceof Error ? error.message : String(error));
+		}
+	}
 
-    // Fallback: robust rewriter for invalid-but-common raw URLs with special chars in userinfo
-    // Pattern: <scheme>://<userinfo>@<host-and-rest>
-    const schemeMatch = raw.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
-    if (!schemeMatch) return raw;
-    const scheme = schemeMatch[1];
-    const startIdx = schemeMatch[0].length;
-    const rest = raw.slice(startIdx);
+	protected executeQueryOptimized(
+		connection: BunSqlConnection,
+		sql: string,
+		args: any[],
+	): Promise<BunSqlResult> {
+		if (args.length === 0) {
+			const strings = this.createTemplateStrings([sql]);
+			return connection(strings);
+		}
 
-    // Find authority boundary (before path/query/fragment)
-    let boundary = rest.length;
-    for (const sep of ['/', '?', '#']) {
-      const idx = rest.indexOf(sep);
-      if (idx !== -1 && idx < boundary) boundary = idx;
-    }
-    const authority = rest.slice(0, boundary);
-    const tail = rest.slice(boundary);
+		const cacheKey = sql;
+		let cached = templateCache.get(cacheKey);
 
-    // Find the last '@' in authority as delimiter for userinfo
-    const at = authority.lastIndexOf('@');
-    if (at === -1) return raw; // no userinfo
+		if (
+			(!cached || cached.paramCount !== args.length) &&
+			this.hasParameterPlaceholders(sql)
+		) {
+			const templateSql = this.convertParameterPlaceholders(sql, args.length);
+			const parts = templateSql.split(/\$\{\d+\}/);
+			const strings = this.createTemplateStrings(parts);
+			const re = /\$\{(\d+)\}/g;
+			const argOrder: number[] = [];
+			let m: RegExpExecArray | null = re.exec(templateSql);
+			while (m !== null) {
+				argOrder.push(Number(m[1]));
+				m = re.exec(templateSql);
+			}
+			cached = { strings, paramCount: args.length, argOrder };
+			templateCache.set(cacheKey, cached);
+		}
 
-    const userinfoRaw = authority.slice(0, at);
-    const hostport = authority.slice(at + 1);
+		if (cached) {
+			const expanded = cached.argOrder?.length
+				? cached.argOrder.map((i) => args[i])
+				: args;
+			const finalArgs =
+				this.provider === "postgres"
+					? this.coerceArgsForPostgres(expanded)
+					: expanded;
+			return connection(cached.strings, ...finalArgs);
+		}
 
-    // Split user:pass (first ':') and encode safely
-    const colon = userinfoRaw.indexOf(':');
-    const userRaw = colon === -1 ? userinfoRaw : userinfoRaw.slice(0, colon);
-    const passRaw = colon === -1 ? '' : userinfoRaw.slice(colon + 1);
+		// Fallback: Query has args but no recognized placeholders
+		// This can happen with Prisma-generated queries that embed parameters differently
+		// We still need to coerce arrays for Postgres compatibility
+		const coercedArgs =
+			this.provider === "postgres" ? this.coerceArgsForPostgres(args) : args;
+		const strings = this.createTemplateStrings([sql]);
+		return connection(strings, ...coercedArgs);
+	}
 
-    // Decode if possible, then encode; if decode fails, encode the raw
-    const safeDecode = (s: string) => {
-      try { return decodeURIComponent(s); } catch { return s; }
-    };
-    const username = encodeURIComponent(safeDecode(userRaw));
-    const password = passRaw !== '' ? encodeURIComponent(safeDecode(passRaw)) : '';
+	protected abstract hasParameterPlaceholders(sql: string): boolean;
+	protected abstract convertParameterPlaceholders(
+		sql: string,
+		paramCount: number,
+	): string;
 
-    const rebuiltAuthority = password ? `${username}:${password}@${hostport}` : `${username}@${hostport}`;
-    return `${scheme}://${rebuiltAuthority}${tail}`;
-  }
+	protected createTemplateStrings(parts: string[]): TemplateStringsArray {
+		if (parts.length === 1) {
+			parts = [...parts, ""];
+		}
+		return Object.assign(parts, { raw: parts }) as TemplateStringsArray;
+	}
 
-  async startTransaction(isolationLevel?: IsolationLevel): Promise<Transaction> {
-    const connection = await this.createConnection();
-    let reserved: BunReservedSqlConnection;
+	// Convert primitive JS arrays to a Postgres array literal string for array-typed columns.
+	// Leaves complex/object arrays untouched to avoid interfering with JSON payloads.
+	protected coerceArgsForPostgres(args: any[]): any[] {
+		const toPgArrayLiteral = (arr: any[]): string => {
+			const encodeItem = (v: any): string => {
+				if (v === null || v === undefined) return "NULL";
+				switch (typeof v) {
+					case "number":
+						return Number.isFinite(v) ? String(v) : "NULL";
+					case "boolean":
+						return v ? "true" : "false";
+					case "string": {
+						const s = v.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+						return `"${s}"`;
+					}
+					default: {
+						try {
+							const s = JSON.stringify(v);
+							const e = s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+							return `"${e}"`;
+						} catch {
+							return "NULL";
+						}
+					}
+				}
+			};
+			return `{${arr.map(encodeItem).join(",")}}`;
+		};
 
-    try {
-      reserved = await connection.reserve();
-    } catch (err) {
-      try {
-        await connection.end();
-      } catch {
-        // ignore shutdown errors
-      }
-      throw err;
-    }
-    let finished = false;
-    let aborted = false;
+		const isPrimitiveArray = (a: any[]): boolean =>
+			Array.isArray(a) &&
+			a.every(
+				(v) => v === null || ["string", "number", "boolean"].includes(typeof v),
+			);
 
-    const releaseReserved = async (): Promise<void> => {
-      try {
-        const maybeRelease = (reserved as any).release?.();
-        if (maybeRelease && typeof maybeRelease.then === "function") {
-          await maybeRelease;
-        }
-      } catch {
-        // ignore release errors
-      }
-    };
+		return args.map((v) =>
+			Array.isArray(v) && isPrimitiveArray(v) ? toPgArrayLiteral(v) : v,
+		);
+	}
 
-    const closeConnection = async (): Promise<void> => {
-      try {
-        await connection.end();
-      } catch {
-        // ignore shutdown errors
-      }
-    };
+	// Normalize and encode credentials in connection string to avoid URI errors
+	protected normalizeConnectionString(input: string): string {
+		const raw = String(input ?? "").trim();
+		if (!raw) return raw;
 
-    const finalizeResources = async (): Promise<void> => {
-      await releaseReserved();
-      await closeConnection();
-    };
+		// Fast path: try URL parser first and re-encode userinfo
+		try {
+			const parsed = new URL(raw);
+			const scheme = parsed.protocol.replace(":", "");
+			if (
+				[
+					"postgres",
+					"postgresql",
+					"mysql",
+					"mysqls",
+					"sqlite",
+					"file",
+				].includes(scheme)
+			) {
+				// Avoid double-encoding: decode valid %HH triplets first, then encode
+				const decodeTriplets = (s: string) =>
+					s.replace(/%[0-9a-fA-F]{2}/g, (m) => {
+						try {
+							return decodeURIComponent(m);
+						} catch {
+							return m;
+						}
+					});
+				if (parsed.username)
+					parsed.username = encodeURIComponent(decodeTriplets(parsed.username));
+				if (parsed.password)
+					parsed.password = encodeURIComponent(decodeTriplets(parsed.password));
+				return parsed.toString();
+			}
+			return raw;
+		} catch {}
 
-    try {
-      const begin = this.createTemplateStrings(["BEGIN"]);
-      await reserved(begin);
+		// Fallback: robust rewriter for invalid-but-common raw URLs with special chars in userinfo
+		// Pattern: <scheme>://<userinfo>@<host-and-rest>
+		const schemeMatch = raw.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
+		if (!schemeMatch) return raw;
+		const scheme = schemeMatch[1];
+		const startIdx = schemeMatch[0].length;
+		const rest = raw.slice(startIdx);
 
-      if (isolationLevel && this.provider !== "sqlite") {
-        const iso = this.createTemplateStrings([
-          `SET TRANSACTION ISOLATION LEVEL ${isolationLevel}`,
-        ]);
-        await reserved(iso);
-      }
-    } catch (err) {
-      await finalizeResources();
-      throw err;
-    }
+		// Find authority boundary (before path/query/fragment)
+		let boundary = rest.length;
+		for (const sep of ["/", "?", "#"]) {
+			const idx = rest.indexOf(sep);
+			if (idx !== -1 && idx < boundary) boundary = idx;
+		}
+		const authority = rest.slice(0, boundary);
+		const tail = rest.slice(boundary);
 
-    const transaction = ((strings: TemplateStringsArray, ...values: any[]) =>
-      reserved(strings, ...values)) as BunSqlTransaction;
+		// Find the last '@' in authority as delimiter for userinfo
+		const at = authority.lastIndexOf("@");
+		if (at === -1) return raw; // no userinfo
 
-    transaction.commit = async () => {
-      const commit = this.createTemplateStrings(["COMMIT"]);
-      await reserved(commit);
-    };
+		const userinfoRaw = authority.slice(0, at);
+		const hostport = authority.slice(at + 1);
 
-    transaction.rollback = async () => {
-      const rollback = this.createTemplateStrings(["ROLLBACK"]);
-      await reserved(rollback);
-    };
+		// Split user:pass (first ':') and encode safely
+		const colon = userinfoRaw.indexOf(":");
+		const userRaw = colon === -1 ? userinfoRaw : userinfoRaw.slice(0, colon);
+		const passRaw = colon === -1 ? "" : userinfoRaw.slice(colon + 1);
 
-    const finalize = async (action: "commit" | "rollback") => {
-      if (finished) {
-        return;
-      }
+		// Decode if possible, then encode; if decode fails, encode the raw
+		const safeDecode = (s: string) => {
+			try {
+				return decodeURIComponent(s);
+			} catch {
+				return s;
+			}
+		};
+		const username = encodeURIComponent(safeDecode(userRaw));
+		const password =
+			passRaw !== "" ? encodeURIComponent(safeDecode(passRaw)) : "";
 
-      try {
-        if (action === "commit") {
-          await transaction.commit();
-        } else {
-          try {
-            await transaction.rollback();
-          } catch {
-            // ignore rollback errors when already closed
-          }
-        }
-      } finally {
-        finished = true;
-        await finalizeResources();
-      }
-    };
+		const rebuiltAuthority = password
+			? `${username}:${password}@${hostport}`
+			: `${username}@${hostport}`;
+		return `${scheme}://${rebuiltAuthority}${tail}`;
+	}
 
-    const runQuery = async (sql: string, args: any[]): Promise<BunSqlResult> => {
-      if (finished) {
-        throw new Error("Transaction is already closed");
-      }
+	async startTransaction(
+		isolationLevel?: IsolationLevel,
+	): Promise<Transaction> {
+		const connection = await this.createConnection();
+		let reserved: BunReservedSqlConnection;
 
-      try {
-        return await this.executeTransactionQueryOptimized(
-          transaction,
-          sql,
-          args,
-        );
-      } catch (err) {
-        aborted = true;
-        throw err;
-      }
-    };
+		try {
+			reserved = await connection.reserve();
+		} catch (err) {
+			try {
+				await connection.end();
+			} catch {
+				// ignore shutdown errors
+			}
+			throw err;
+		}
+		let finished = false;
+		let aborted = false;
 
-    return {
-      provider: this.provider,
-      adapterName: this.adapterName,
-      options: {
-        usePhantomQuery: false,
-      },
-      queryRaw: async (query: SqlQuery) => {
-        const result = await runQuery(query.sql, query.args || []);
+		const releaseReserved = async (): Promise<void> => {
+			try {
+				const maybeRelease = (reserved as any).release?.();
+				if (maybeRelease && typeof maybeRelease.then === "function") {
+					await maybeRelease;
+				}
+			} catch {
+				// ignore release errors
+			}
+		};
 
-        if (!Array.isArray(result) || result.length === 0) {
-          return { columnNames: [], columnTypes: [], rows: [] };
-        }
+		const closeConnection = async (): Promise<void> => {
+			try {
+				await connection.end();
+			} catch {
+				// ignore shutdown errors
+			}
+		};
 
-        const firstRow = result[0];
-        const columnNames = Object.keys(firstRow);
-        const columnCount = columnNames.length;
+		const finalizeResources = async (): Promise<void> => {
+			await releaseReserved();
+			await closeConnection();
+		};
 
-        const columnTypes = this.determineColumnTypes(result, columnNames);
-        const rows = new Array(result.length);
+		try {
+			const begin = this.createTemplateStrings(["BEGIN"]);
+			await reserved(begin);
 
-        for (let rowIndex = 0; rowIndex < result.length; rowIndex++) {
-          const row = result[rowIndex];
-          const processedRow = new Array(columnCount);
+			if (isolationLevel && this.provider !== "sqlite") {
+				const iso = this.createTemplateStrings([
+					`SET TRANSACTION ISOLATION LEVEL ${isolationLevel}`,
+				]);
+				await reserved(iso);
+			}
+		} catch (err) {
+			await finalizeResources();
+			throw err;
+		}
 
-          for (let colIndex = 0; colIndex < columnCount; colIndex++) {
-            const val = row[columnNames[colIndex]];
-            processedRow[colIndex] =
-              columnTypes[colIndex] === ColumnTypeEnum.Json
-                ? this.ensureJsonString(val)
-                : this.serializeValueFast(val);
-          }
+		const transaction = ((strings: TemplateStringsArray, ...values: any[]) =>
+			reserved(strings, ...values)) as BunSqlTransaction;
 
-          rows[rowIndex] = processedRow;
-        }
+		transaction.commit = async () => {
+			const commit = this.createTemplateStrings(["COMMIT"]);
+			await reserved(commit);
+		};
 
-        return { columnNames, columnTypes, rows };
-      },
-      executeRaw: async (query: SqlQuery) => {
-        const result = await runQuery(query.sql, query.args || []);
-        return result.affectedRows || result.count || 0;
-      },
-      commit: async () => {
-        if (finished) {
-          return;
-        }
+		transaction.rollback = async () => {
+			const rollback = this.createTemplateStrings(["ROLLBACK"]);
+			await reserved(rollback);
+		};
 
-        if (aborted) {
-          await finalize("rollback");
-          throw new Error("Transaction rolled back due to a previous error");
-        }
+		const finalize = async (action: "commit" | "rollback") => {
+			if (finished) {
+				return;
+			}
 
-        try {
-          await finalize("commit");
-        } catch (err) {
-          await finalize("rollback").catch(() => {});
-          throw err;
-        }
-      },
-      rollback: async () => {
-        await finalize("rollback");
-      },
-    };
-  }
+			try {
+				if (action === "commit") {
+					await transaction.commit();
+				} else {
+					try {
+						await transaction.rollback();
+					} catch {
+						// ignore rollback errors when already closed
+					}
+				}
+			} finally {
+				finished = true;
+				await finalizeResources();
+			}
+		};
 
-  protected determineColumnTypes(result: any[], columnNames: string[]): ColumnType[] {
-    const columnCount = columnNames.length;
-    const types = new Array(columnCount) as ColumnType[];
-    for (let i = 0; i < columnCount; i++) {
-      const name = columnNames[i];
-      let isJson = false;
-      for (let r = 0; r < result.length; r++) {
-        const v = result[r][name];
-        if (v === null || v === undefined) continue;
-        const t = typeof v;
-        if (t === 'object') {
-          if (v instanceof Date || Buffer.isBuffer(v)) {
-            // not JSON
-          } else {
-            isJson = true; break;
-          }
-        } else if (t === 'string') {
-          const s = (v as string).trim();
-          if (this.isJsonishString(s)) { isJson = true; break; }
-        }
-      }
-      if (isJson) {
-        types[i] = ColumnTypeEnum.Json;
-      } else {
-        // fallback to firstRow inference
-        types[i] = this.inferColumnTypeFast(result[0]?.[name]);
-      }
-    }
-    return types;
-  }
+		const runQuery = async (
+			sql: string,
+			args: any[],
+		): Promise<BunSqlResult> => {
+			if (finished) {
+				throw new Error("Transaction is already closed");
+			}
 
-  protected isJsonishString(s: string): boolean {
-    if (!s) return false;
-    const t = s.trim();
-    if (!t) return false;
-    if (t.startsWith('{') || t.startsWith('[')) return true;
-    if (t.startsWith('"') && t.endsWith('"')) return true;
-    return false;
-  }
+			try {
+				return await this.executeTransactionQueryOptimized(
+					transaction,
+					sql,
+					args,
+				);
+			} catch (err) {
+				aborted = true;
+				throw err;
+			}
+		};
 
-  protected ensureJsonString(value: unknown): string {
-    if (value === null || value === undefined) return 'null';
-    const t = typeof value;
-    if (t === 'string') {
-      const s = (value as string);
-      return this.isJsonishString(s) ? s : JSON.stringify(s);
-    }
-    if (t === 'number' || t === 'boolean') return JSON.stringify(value);
-    if (value instanceof Date) return JSON.stringify(value.toISOString());
-    if (Buffer.isBuffer(value)) return JSON.stringify(Array.from(value as unknown as Uint8Array));
-    try { return JSON.stringify(value); } catch { return 'null'; }
-  }
+		return {
+			provider: this.provider,
+			adapterName: this.adapterName,
+			options: {
+				usePhantomQuery: false,
+			},
+			queryRaw: async (query: SqlQuery) => {
+				const result = await runQuery(query.sql, query.args || []);
 
-  protected executeTransactionQueryOptimized(tx: BunSqlTransaction, sql: string, args: any[]): Promise<BunSqlResult> {
-    if (args.length === 0) {
-      const strings = this.createTemplateStrings([sql]);
-      return tx(strings);
-    }
-    
-    if (this.hasParameterPlaceholders(sql)) {
-      const templateSql = this.convertParameterPlaceholders(sql, args.length);
-      const parts = templateSql.split(/\$\{\d+\}/);
-      const strings = this.createTemplateStrings(parts);
-      const argOrder: number[] = [];
-      const re = /\$\{(\d+)\}/g;
-      let m: RegExpExecArray | null;
-      while ((m = re.exec(templateSql)) !== null) {
-        argOrder.push(Number(m[1]));
-      }
-      const expanded = argOrder.length ? argOrder.map((i) => args[i]) : args;
-      const finalArgs = this.provider === 'postgres' ? this.coerceArgsForPostgres(expanded) : expanded;
-      return tx(strings, ...finalArgs);
-    }
-    
-    const strings = this.createTemplateStrings([sql]);
-    return tx(strings);
-  }
+				if (!Array.isArray(result) || result.length === 0) {
+					return { columnNames: [], columnTypes: [], rows: [] };
+				}
 
-  protected inferColumnTypeFast(value: unknown): ColumnType {
-    if (value === null || value === undefined) {
-      return ColumnTypeEnum.UnknownNumber;
-    }
-    
-    const valueType = typeof value;
-    
-    switch (valueType) {
-      case "boolean":
-        return ColumnTypeEnum.Boolean;
-      case "number":
-        return Number.isInteger(value) ? ColumnTypeEnum.Int32 : ColumnTypeEnum.Double;
-      case "bigint":
-        return ColumnTypeEnum.Int64;
-      case "string":
-        if (DATETIME_REGEX.test(value as string)) {
-          return ColumnTypeEnum.DateTime;
-        }
-        if (DATE_REGEX.test(value as string)) {
-          return ColumnTypeEnum.Date;
-        }
-        if (UUID_REGEX.test(value as string)) {
-          return ColumnTypeEnum.Uuid;
-        }
-        return ColumnTypeEnum.Text;
-      case "object":
-        if (value instanceof Date) {
-          return ColumnTypeEnum.DateTime;
-        }
-        if (Buffer.isBuffer(value)) {
-          return ColumnTypeEnum.Bytes;
-        }
-        return ColumnTypeEnum.Json;
-      default:
-        return ColumnTypeEnum.UnknownNumber;
-    }
-  }
+				const firstRow = result[0];
+				const columnNames = Object.keys(firstRow);
+				const columnCount = columnNames.length;
 
-  protected serializeValueFast(value: unknown): unknown {
-    if (value === null || value === undefined) {
-      return value;
-    }
-    
-    const valueType = typeof value;
-    
-    if (valueType === "string" || valueType === "number" || valueType === "boolean") {
-      return value;
-    }
-    
-    if (valueType === "bigint") {
-      return value.toString();
-    }
-    
-    if (value instanceof Date) {
-      return value.toISOString();
-    }
-    
-    if (Buffer.isBuffer(value)) {
-      return value;
-    }
-    
-    // For JSON/object-like values, return a valid JSON string to satisfy
-    // Prisma driver-adapter-utils which parses JSON columns from strings
-    try {
-      return JSON.stringify(value);
-    } catch {
-      // Fallback to string coercion if JSON.stringify fails for any reason
-      return String(value);
-    }
-  }
+				const columnTypes = this.determineColumnTypes(result, columnNames);
+				const rows = new Array(result.length);
+
+				for (let rowIndex = 0; rowIndex < result.length; rowIndex++) {
+					const row = result[rowIndex];
+					const processedRow = new Array(columnCount);
+
+					for (let colIndex = 0; colIndex < columnCount; colIndex++) {
+						const val = row[columnNames[colIndex]];
+						processedRow[colIndex] =
+							columnTypes[colIndex] === ColumnTypeEnum.Json
+								? this.ensureJsonString(val)
+								: this.serializeValueFast(val);
+					}
+
+					rows[rowIndex] = processedRow;
+				}
+
+				return { columnNames, columnTypes, rows };
+			},
+			executeRaw: async (query: SqlQuery) => {
+				const result = await runQuery(query.sql, query.args || []);
+				return result.affectedRows || result.count || 0;
+			},
+			commit: async () => {
+				if (finished) {
+					return;
+				}
+
+				if (aborted) {
+					await finalize("rollback");
+					throw new Error("Transaction rolled back due to a previous error");
+				}
+
+				try {
+					await finalize("commit");
+				} catch (err) {
+					await finalize("rollback").catch(() => {});
+					throw err;
+				}
+			},
+			rollback: async () => {
+				await finalize("rollback");
+			},
+		};
+	}
+
+	protected determineColumnTypes(
+		result: any[],
+		columnNames: string[],
+	): ColumnType[] {
+		const columnCount = columnNames.length;
+		const types = new Array(columnCount) as ColumnType[];
+		for (let i = 0; i < columnCount; i++) {
+			const name = columnNames[i];
+
+			// Check if column contains arrays (must check ALL rows, not just first)
+			let hasArray = false;
+			let hasOtherObjects = false;
+
+			for (let r = 0; r < result.length; r++) {
+				const v = result[r][name];
+				if (v === null || v === undefined) continue;
+
+				if (Array.isArray(v)) {
+					hasArray = true;
+					break; // Found an array, stop checking
+				} else if (
+					typeof v === "object" &&
+					!(v instanceof Date) &&
+					!Buffer.isBuffer(v)
+				) {
+					hasOtherObjects = true;
+				}
+			}
+
+			// If ANY row has an array in this column, it's an array column (NOT JSON)
+			if (hasArray) {
+				// Return a generic type for arrays - let Prisma handle the specifics
+				types[i] = ColumnTypeEnum.UnknownNumber; // Prisma will infer from schema
+			} else if (hasOtherObjects) {
+				// Only non-array objects are JSON
+				types[i] = ColumnTypeEnum.Json;
+			} else {
+				// Fallback to type inference
+				types[i] = this.inferColumnTypeFast(result[0]?.[name]);
+			}
+		}
+		return types;
+	}
+
+	protected isJsonishString(s: string): boolean {
+		if (!s) return false;
+		const t = s.trim();
+		if (!t) return false;
+		if (t.startsWith("{") || t.startsWith("[")) return true;
+		if (t.startsWith('"') && t.endsWith('"')) return true;
+		return false;
+	}
+
+	protected ensureJsonString(value: unknown): string {
+		if (value === null || value === undefined) return "null";
+		const t = typeof value;
+		if (t === "string") {
+			const s = value as string;
+			return this.isJsonishString(s) ? s : JSON.stringify(s);
+		}
+		if (t === "number" || t === "boolean") return JSON.stringify(value);
+		if (value instanceof Date) return JSON.stringify(value.toISOString());
+		if (Buffer.isBuffer(value))
+			return JSON.stringify(Array.from(value as unknown as Uint8Array));
+		try {
+			return JSON.stringify(value);
+		} catch {
+			return "null";
+		}
+	}
+
+	protected executeTransactionQueryOptimized(
+		tx: BunSqlTransaction,
+		sql: string,
+		args: any[],
+	): Promise<BunSqlResult> {
+		if (args.length === 0) {
+			const strings = this.createTemplateStrings([sql]);
+			return tx(strings);
+		}
+
+		if (this.hasParameterPlaceholders(sql)) {
+			const templateSql = this.convertParameterPlaceholders(sql, args.length);
+			const parts = templateSql.split(/\$\{\d+\}/);
+			const strings = this.createTemplateStrings(parts);
+			const re = /\$\{(\d+)\}/g;
+			const argOrder: number[] = [];
+			let m: RegExpExecArray | null = re.exec(templateSql);
+			while (m !== null) {
+				argOrder.push(Number(m[1]));
+				m = re.exec(templateSql);
+			}
+			const expanded = argOrder.length ? argOrder.map((i) => args[i]) : args;
+			const finalArgs =
+				this.provider === "postgres"
+					? this.coerceArgsForPostgres(expanded)
+					: expanded;
+			return tx(strings, ...finalArgs);
+		}
+
+		// Fallback: Transaction query has args but no recognized placeholders
+		// Apply array coercion for Postgres compatibility
+		const coercedArgs =
+			this.provider === "postgres" ? this.coerceArgsForPostgres(args) : args;
+		const strings = this.createTemplateStrings([sql]);
+		return tx(strings, ...coercedArgs);
+	}
+
+	protected inferColumnTypeFast(value: unknown): ColumnType {
+		if (value === null || value === undefined) {
+			return ColumnTypeEnum.UnknownNumber;
+		}
+
+		const valueType = typeof value;
+
+		switch (valueType) {
+			case "boolean":
+				return ColumnTypeEnum.Boolean;
+			case "number":
+				return Number.isInteger(value)
+					? ColumnTypeEnum.Int32
+					: ColumnTypeEnum.Double;
+			case "bigint":
+				return ColumnTypeEnum.Int64;
+			case "string":
+				if (DATETIME_REGEX.test(value as string)) {
+					return ColumnTypeEnum.DateTime;
+				}
+				if (DATE_REGEX.test(value as string)) {
+					return ColumnTypeEnum.Date;
+				}
+				if (UUID_REGEX.test(value as string)) {
+					return ColumnTypeEnum.Uuid;
+				}
+				return ColumnTypeEnum.Text;
+			case "object":
+				if (value instanceof Date) {
+					return ColumnTypeEnum.DateTime;
+				}
+				if (Buffer.isBuffer(value)) {
+					return ColumnTypeEnum.Bytes;
+				}
+				return ColumnTypeEnum.Json;
+			default:
+				return ColumnTypeEnum.UnknownNumber;
+		}
+	}
+
+	protected serializeValueFast(value: unknown): unknown {
+		if (value === null || value === undefined) {
+			return value;
+		}
+
+		const valueType = typeof value;
+
+		if (
+			valueType === "string" ||
+			valueType === "number" ||
+			valueType === "boolean"
+		) {
+			return value;
+		}
+
+		if (valueType === "bigint") {
+			return value.toString();
+		}
+
+		if (value instanceof Date) {
+			return value.toISOString();
+		}
+
+		if (Buffer.isBuffer(value)) {
+			return value;
+		}
+
+		// CRITICAL: If value is an array, return it as-is
+		// Prisma expects arrays for array-typed columns (text[], int[], etc.)
+		// Converting to JSON string breaks Prisma's .map() calls
+		if (Array.isArray(value)) {
+			return value;
+		}
+
+		// For JSON/object-like values, return a valid JSON string to satisfy
+		// Prisma driver-adapter-utils which parses JSON columns from strings
+		try {
+			return JSON.stringify(value);
+		} catch {
+			// Fallback to string coercion if JSON.stringify fails for any reason
+			return String(value);
+		}
+	}
 }
 
 // PostgreSQL Adapter
 class BunPostgresDriverAdapter extends BaseBunDriverAdapter {
-  readonly provider = "postgres" as const;
-  readonly adapterName = "bun-postgres-adapter";
+	readonly provider = "postgres" as const;
+	readonly adapterName = "bun-postgres-adapter";
 
-  protected async createConnection(): Promise<BunSqlConnection> {
-    const BunSQL = (globalThis as any).Bun?.sql;
-    if (!BunSQL) {
-      throw new Error("Bun's native SQL client is not available. Make sure you're running with Bun 1.3+");
-    }
+	protected async createConnection(): Promise<BunSqlConnection> {
+		const BunSQL = (globalThis as any).Bun?.sql;
+		if (!BunSQL) {
+			throw new Error(
+				"Bun's native SQL client is not available. Make sure you're running with Bun 1.3+",
+			);
+		}
 
-    const candidates = this.buildPgConnectionCandidates(this.connectionString);
-    let lastErr: any = null;
-    for (const candidate of candidates) {
-      try {
-        const conn = new BunSQL(candidate) as BunSqlConnection;
-        try {
-          const strings = this.createTemplateStrings(['SELECT 1']);
-          await conn(strings);
-          return conn;
-        } catch (warmErr: any) {
-          if (this.isPgAuthFailed(warmErr)) {
-            lastErr = warmErr;
-            continue;
-          }
-          throw warmErr;
-        }
-      } catch (e: any) {
-        lastErr = e;
-        continue;
-      }
-    }
+		const candidates = this.buildPgConnectionCandidates(this.connectionString);
+		let lastErr: any = null;
+		for (const candidate of candidates) {
+			try {
+				const conn = new BunSQL(candidate) as BunSqlConnection;
+				try {
+					const strings = this.createTemplateStrings(["SELECT 1"]);
+					await conn(strings);
+					return conn;
+				} catch (warmErr: any) {
+					if (this.isPgAuthFailed(warmErr)) {
+						lastErr = warmErr;
+						continue;
+					}
+					throw warmErr;
+				}
+			} catch (e: any) {
+				lastErr = e;
+				continue;
+			}
+		}
 
-    if (lastErr && (lastErr instanceof URIError || (typeof lastErr?.message === 'string' && /uri/i.test(lastErr.message)))) {
-      throw new Error(
-        "Invalid DATABASE_URL/connectionString. Check URL shape; credentials are auto-encoded by the adapter."
-      );
-    }
-    throw lastErr ?? new Error('Failed to establish Postgres connection');
-  }
+		if (
+			lastErr &&
+			(lastErr instanceof URIError ||
+				(typeof lastErr?.message === "string" && /uri/i.test(lastErr.message)))
+		) {
+			throw new Error(
+				"Invalid DATABASE_URL/connectionString. Check URL shape; credentials are auto-encoded by the adapter.",
+			);
+		}
+		throw lastErr ?? new Error("Failed to establish Postgres connection");
+	}
 
-  private isPgAuthFailed(err: any): boolean {
-    const msg = String(err?.message ?? '').toLowerCase();
-    return msg.includes('password authentication failed') || msg.includes('28p01');
-  }
+	private isPgAuthFailed(err: any): boolean {
+		const msg = String(err?.message ?? "").toLowerCase();
+		return (
+			msg.includes("password authentication failed") || msg.includes("28p01")
+		);
+	}
 
-  private buildPgConnectionCandidates(input: string): string[] {
-    const raw = String(input ?? '').trim();
-    const normalized = this.normalizeConnectionString(raw);
-    const out: string[] = [];
-    if (normalized) out.push(normalized);
-    if (raw && raw !== normalized) out.push(raw);
-    const qpVariant = this.toPgPasswordQueryVariant(raw);
-    if (qpVariant && !out.includes(qpVariant)) out.push(qpVariant);
-    return out;
-  }
+	private buildPgConnectionCandidates(input: string): string[] {
+		const raw = String(input ?? "").trim();
+		const normalized = this.normalizeConnectionString(raw);
+		const out: string[] = [];
+		if (normalized) out.push(normalized);
+		if (raw && raw !== normalized) out.push(raw);
+		const qpVariant = this.toPgPasswordQueryVariant(raw);
+		if (qpVariant && !out.includes(qpVariant)) out.push(qpVariant);
+		return out;
+	}
 
-  private toPgPasswordQueryVariant(raw: string): string | null {
-    const m = raw.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
-    if (!m) return null;
-    const scheme = m[1];
-    if (!['postgres', 'postgresql'].includes(scheme)) return null;
-    const start = m[0].length;
-    const rest = raw.slice(start);
-    let boundary = rest.length;
-    for (const sep of ['/', '?', '#']) {
-      const idx = rest.indexOf(sep);
-      if (idx !== -1 && idx < boundary) boundary = idx;
-    }
-    const authority = rest.slice(0, boundary);
-    const tail = rest.slice(boundary);
-    const at = authority.lastIndexOf('@');
-    if (at === -1) return null;
-    const userinfo = authority.slice(0, at);
-    const hostport = authority.slice(at + 1);
-    const colon = userinfo.indexOf(':');
-    const userRaw = colon === -1 ? userinfo : userinfo.slice(0, colon);
-    const passRaw = colon === -1 ? '' : userinfo.slice(colon + 1);
-    if (!passRaw) return null;
-    const safeDecode = (s: string) => { try { return decodeURIComponent(s); } catch { return s; } };
-    const username = encodeURIComponent(safeDecode(userRaw));
-    const passwordRaw = safeDecode(passRaw);
-    let path = tail;
-    let existingQuery = '';
-    const qIdx = tail.indexOf('?');
-    if (qIdx !== -1) {
-      path = tail.slice(0, qIdx);
-      existingQuery = tail.slice(qIdx + 1);
-    }
-    const join = existingQuery ? '&' : '?';
-    const finalQuery = `${existingQuery ? '?' + existingQuery : ''}${join}password=${encodeURIComponent(passwordRaw)}`;
-    return `${scheme}://${username}@${hostport}${path}${finalQuery}`;
-  }
+	private toPgPasswordQueryVariant(raw: string): string | null {
+		const m = raw.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
+		if (!m) return null;
+		const scheme = m[1];
+		if (!["postgres", "postgresql"].includes(scheme)) return null;
+		const start = m[0].length;
+		const rest = raw.slice(start);
+		let boundary = rest.length;
+		for (const sep of ["/", "?", "#"]) {
+			const idx = rest.indexOf(sep);
+			if (idx !== -1 && idx < boundary) boundary = idx;
+		}
+		const authority = rest.slice(0, boundary);
+		const tail = rest.slice(boundary);
+		const at = authority.lastIndexOf("@");
+		if (at === -1) return null;
+		const userinfo = authority.slice(0, at);
+		const hostport = authority.slice(at + 1);
+		const colon = userinfo.indexOf(":");
+		const userRaw = colon === -1 ? userinfo : userinfo.slice(0, colon);
+		const passRaw = colon === -1 ? "" : userinfo.slice(colon + 1);
+		if (!passRaw) return null;
+		const safeDecode = (s: string) => {
+			try {
+				return decodeURIComponent(s);
+			} catch {
+				return s;
+			}
+		};
+		const username = encodeURIComponent(safeDecode(userRaw));
+		const passwordRaw = safeDecode(passRaw);
+		let path = tail;
+		let existingQuery = "";
+		const qIdx = tail.indexOf("?");
+		if (qIdx !== -1) {
+			path = tail.slice(0, qIdx);
+			existingQuery = tail.slice(qIdx + 1);
+		}
+		const join = existingQuery ? "&" : "?";
+		const finalQuery = `${existingQuery ? "?" + existingQuery : ""}${join}password=${encodeURIComponent(passwordRaw)}`;
+		return `${scheme}://${username}@${hostport}${path}${finalQuery}`;
+	}
 
-  protected hasParameterPlaceholders(sql: string): boolean {
-    // Postgres uses $n placeholders. Do not treat '?' as a placeholder to avoid
-    // collisions with JSONB operators like '?' and '?|'.
-    return sql.includes('$1');
-  }
+	protected hasParameterPlaceholders(sql: string): boolean {
+		// Postgres uses $n placeholders. Do not treat '?' as a placeholder to avoid
+		// collisions with JSONB operators like '?' and '?|'.
+		return sql.includes("$1");
+	}
 
-  protected convertParameterPlaceholders(sql: string, paramCount: number): string {
-    let templateSql = sql;
-    if (sql.includes('$1')) {
-      // Replace from highest index to lowest to avoid $1 matching in $10, $11, ...
-      for (let n = paramCount; n >= 1; n--) {
-        const idx = n - 1;
-        const marker = '${' + idx + '}';
-        templateSql = templateSql.replaceAll(`$${n}`, marker);
-      }
-      return templateSql;
-    }
-    // Fallback: convert '?' placeholders sequentially
-    for (let i = 0; i < paramCount; i++) {
-      const marker = '${' + i + '}';
-      templateSql = templateSql.replace('?', marker);
-    }
-    return templateSql;
-  }
+	protected convertParameterPlaceholders(
+		sql: string,
+		paramCount: number,
+	): string {
+		let templateSql = sql;
+		if (sql.includes("$1")) {
+			// Replace from highest index to lowest to avoid $1 matching in $10, $11, ...
+			for (let n = paramCount; n >= 1; n--) {
+				const idx = n - 1;
+				const marker = "${" + idx + "}";
+				templateSql = templateSql.replaceAll(`$${n}`, marker);
+			}
+			return templateSql;
+		}
+		// Fallback: convert '?' placeholders sequentially
+		for (let i = 0; i < paramCount; i++) {
+			const marker = "${" + i + "}";
+			templateSql = templateSql.replace("?", marker);
+		}
+		return templateSql;
+	}
 }
 
 // MySQL Adapter
 class BunMySQLDriverAdapter extends BaseBunDriverAdapter {
-  readonly provider = "mysql" as const;
-  readonly adapterName = "bun-mysql-adapter";
+	readonly provider = "mysql" as const;
+	readonly adapterName = "bun-mysql-adapter";
 
-  protected async createConnection(): Promise<BunSqlConnection> {
-    const BunSQL = (globalThis as any).Bun?.sql;
-    if (!BunSQL) {
-      throw new Error("Bun's native SQL client is not available. Make sure you're running with Bun 1.3+");
-    }
+	protected async createConnection(): Promise<BunSqlConnection> {
+		const BunSQL = (globalThis as any).Bun?.sql;
+		if (!BunSQL) {
+			throw new Error(
+				"Bun's native SQL client is not available. Make sure you're running with Bun 1.3+",
+			);
+		}
 
-    const normalized = this.normalizeConnectionString(this.connectionString);
-    let connection: BunSqlConnection;
-    try {
-      connection = new BunSQL(normalized) as BunSqlConnection;
-    } catch (e: any) {
-      if (e instanceof URIError || (typeof e?.message === 'string' && /uri/i.test(e.message))) {
-        throw new Error(
-          "Invalid DATABASE_URL/connectionString. Ensure username/password are percent-encoded (e.g. '@' -> '%40', ':' -> '%3A', '/' -> '%2F')."
-        );
-      }
-      throw e;
-    }
-    
-    // Warm up the connection
-    try {
-      const strings = this.createTemplateStrings(['SELECT 1']);
-      await connection(strings);
-    } catch (error) {
-      // Ignore warm-up errors
-    }
-    
-    return connection;
-  }
+		const normalized = this.normalizeConnectionString(this.connectionString);
+		let connection: BunSqlConnection;
+		try {
+			connection = new BunSQL(normalized) as BunSqlConnection;
+		} catch (e: any) {
+			if (
+				e instanceof URIError ||
+				(typeof e?.message === "string" && /uri/i.test(e.message))
+			) {
+				throw new Error(
+					"Invalid DATABASE_URL/connectionString. Ensure username/password are percent-encoded (e.g. '@' -> '%40', ':' -> '%3A', '/' -> '%2F').",
+				);
+			}
+			throw e;
+		}
 
-  protected hasParameterPlaceholders(sql: string): boolean {
-    return sql.includes('?');
-  }
+		// Warm up the connection
+		try {
+			const strings = this.createTemplateStrings(["SELECT 1"]);
+			await connection(strings);
+		} catch (error) {
+			// Ignore warm-up errors
+		}
 
-  protected convertParameterPlaceholders(sql: string, paramCount: number): string {
-    let templateSql = sql;
-    for (let i = 0; i < paramCount; i++) {
-      const marker = '${' + i + '}';
-      templateSql = templateSql.replace('?', marker);
-    }
-    return templateSql;
-  }
+		return connection;
+	}
+
+	protected hasParameterPlaceholders(sql: string): boolean {
+		return sql.includes("?");
+	}
+
+	protected convertParameterPlaceholders(
+		sql: string,
+		paramCount: number,
+	): string {
+		let templateSql = sql;
+		for (let i = 0; i < paramCount; i++) {
+			const marker = "${" + i + "}";
+			templateSql = templateSql.replace("?", marker);
+		}
+		return templateSql;
+	}
 }
 
 // SQLite Adapter
 class BunSQLiteDriverAdapter extends BaseBunDriverAdapter {
-  readonly provider = "sqlite" as const;
-  readonly adapterName = "bun-sqlite-adapter";
+	readonly provider = "sqlite" as const;
+	readonly adapterName = "bun-sqlite-adapter";
 
-  protected async createConnection(): Promise<BunSqlConnection> {
-    const BunSQL = (globalThis as any).Bun?.sql;
-    if (!BunSQL) {
-      throw new Error("Bun's native SQL client is not available. Make sure you're running with Bun 1.3+");
-    }
+	protected async createConnection(): Promise<BunSqlConnection> {
+		const BunSQL = (globalThis as any).Bun?.sql;
+		if (!BunSQL) {
+			throw new Error(
+				"Bun's native SQL client is not available. Make sure you're running with Bun 1.3+",
+			);
+		}
 
-    const normalized = this.normalizeConnectionString(this.connectionString);
-    let connection: BunSqlConnection;
-    try {
-      connection = new BunSQL(normalized) as BunSqlConnection;
-    } catch (e: any) {
-      if (e instanceof URIError || (typeof e?.message === 'string' && /uri/i.test(e.message))) {
-        throw new Error(
-          "Invalid DATABASE_URL/connectionString. Ensure username/password are percent-encoded (e.g. '@' -> '%40', ':' -> '%3A', '/' -> '%2F')."
-        );
-      }
-      throw e;
-    }
-    
-    // Warm up the connection
-    try {
-      const strings = this.createTemplateStrings(['SELECT 1']);
-      await connection(strings);
-    } catch (error) {
-      // Ignore warm-up errors
-    }
-    
-    return connection;
-  }
+		const normalized = this.normalizeConnectionString(this.connectionString);
+		let connection: BunSqlConnection;
+		try {
+			connection = new BunSQL(normalized) as BunSqlConnection;
+		} catch (e: any) {
+			if (
+				e instanceof URIError ||
+				(typeof e?.message === "string" && /uri/i.test(e.message))
+			) {
+				throw new Error(
+					"Invalid DATABASE_URL/connectionString. Ensure username/password are percent-encoded (e.g. '@' -> '%40', ':' -> '%3A', '/' -> '%2F').",
+				);
+			}
+			throw e;
+		}
 
-  protected hasParameterPlaceholders(sql: string): boolean {
-    return sql.includes('?');
-  }
+		// Warm up the connection
+		try {
+			const strings = this.createTemplateStrings(["SELECT 1"]);
+			await connection(strings);
+		} catch (error) {
+			// Ignore warm-up errors
+		}
 
-  protected convertParameterPlaceholders(sql: string, paramCount: number): string {
-    let templateSql = sql;
-    for (let i = 0; i < paramCount; i++) {
-      const marker = '${' + i + '}';
-      templateSql = templateSql.replace('?', marker);
-    }
-    return templateSql;
-  }
+		return connection;
+	}
+
+	protected hasParameterPlaceholders(sql: string): boolean {
+		return sql.includes("?");
+	}
+
+	protected convertParameterPlaceholders(
+		sql: string,
+		paramCount: number,
+	): string {
+		let templateSql = sql;
+		for (let i = 0; i < paramCount; i++) {
+			const marker = "${" + i + "}";
+			templateSql = templateSql.replace("?", marker);
+		}
+		return templateSql;
+	}
 }
 
 // Adapter factory classes
 export class BunPostgresAdapter {
-  readonly provider = "postgres" as const;
-  readonly adapterName = "bun-postgres-adapter";
-  private config: BunPostgresConfig | string;
+	readonly provider = "postgres" as const;
+	readonly adapterName = "bun-postgres-adapter";
+	private config: BunPostgresConfig | string;
 
-  constructor(config: BunPostgresConfig | string) {
-    this.config = config;
-  }
+	constructor(config: BunPostgresConfig | string) {
+		this.config = config;
+	}
 
-  async connect(): Promise<SqlDriverAdapter> {
-    const connectionString = typeof this.config === "string" 
-      ? this.config 
-      : this.config.connectionString;
-    
-    const maxConnections = typeof this.config === "string" 
-      ? 5
-      : (this.config.maxConnections || 5);
-    
-    return new BunPostgresDriverAdapter(connectionString, maxConnections);
-  }
+	async connect(): Promise<SqlDriverAdapter> {
+		const connectionString =
+			typeof this.config === "string"
+				? this.config
+				: this.config.connectionString;
 
-  async dispose(): Promise<void> {}
+		const maxConnections =
+			typeof this.config === "string" ? 5 : this.config.maxConnections || 5;
+
+		return new BunPostgresDriverAdapter(connectionString, maxConnections);
+	}
+
+	async dispose(): Promise<void> {}
 }
 
 export class BunMySQLAdapter {
-  readonly provider = "mysql" as const;
-  readonly adapterName = "bun-mysql-adapter";
-  private config: BunMySQLConfig | string;
+	readonly provider = "mysql" as const;
+	readonly adapterName = "bun-mysql-adapter";
+	private config: BunMySQLConfig | string;
 
-  constructor(config: BunMySQLConfig | string) {
-    this.config = config;
-  }
+	constructor(config: BunMySQLConfig | string) {
+		this.config = config;
+	}
 
-  async connect(): Promise<SqlDriverAdapter> {
-    const connectionString = typeof this.config === "string" 
-      ? this.config 
-      : this.config.connectionString;
-    
-    const maxConnections = typeof this.config === "string" 
-      ? 5
-      : (this.config.maxConnections || 5);
-    
-    return new BunMySQLDriverAdapter(connectionString, maxConnections);
-  }
+	async connect(): Promise<SqlDriverAdapter> {
+		const connectionString =
+			typeof this.config === "string"
+				? this.config
+				: this.config.connectionString;
 
-  async dispose(): Promise<void> {}
+		const maxConnections =
+			typeof this.config === "string" ? 5 : this.config.maxConnections || 5;
+
+		return new BunMySQLDriverAdapter(connectionString, maxConnections);
+	}
+
+	async dispose(): Promise<void> {}
 }
 
 export class BunSQLiteAdapter {
-  readonly provider = "sqlite" as const;
-  readonly adapterName = "bun-sqlite-adapter";
-  private config: BunSQLiteConfig | string;
+	readonly provider = "sqlite" as const;
+	readonly adapterName = "bun-sqlite-adapter";
+	private config: BunSQLiteConfig | string;
 
-  constructor(config: BunSQLiteConfig | string) {
-    this.config = config;
-  }
+	constructor(config: BunSQLiteConfig | string) {
+		this.config = config;
+	}
 
-  async connect(): Promise<SqlDriverAdapter> {
-    const connectionString = typeof this.config === "string" 
-      ? this.config 
-      : `file:${this.config.filename}`;
-    
-    const maxConnections = typeof this.config === "string" 
-      ? 1  // SQLite typically uses single connection
-      : (this.config.maxConnections || 1);
-    
-    return new BunSQLiteDriverAdapter(connectionString, maxConnections);
-  }
+	async connect(): Promise<SqlDriverAdapter> {
+		const connectionString =
+			typeof this.config === "string"
+				? this.config
+				: `file:${this.config.filename}`;
 
-  async dispose(): Promise<void> {}
+		const maxConnections =
+			typeof this.config === "string"
+				? 1 // SQLite typically uses single connection
+				: this.config.maxConnections || 1;
+
+		return new BunSQLiteDriverAdapter(connectionString, maxConnections);
+	}
+
+	async dispose(): Promise<void> {}
 }
 
 // Default export for backward compatibility
@@ -921,7 +1069,7 @@ export default BunPostgresAdapter;
 // Re-export optimized Postgres for convenience so consumers can opt-in
 // without changing import path structure if they prefer a named export.
 export {
-  BunPostgresAdapter as OptimizedBunPostgresAdapter,
-  BunPostgresAdapter as BunPostgresOptimized,
-  OptimizedBunPostgresDriverAdapter,
-} from './optimized-index.js';
+	BunPostgresAdapter as OptimizedBunPostgresAdapter,
+	BunPostgresAdapter as BunPostgresOptimized,
+	OptimizedBunPostgresDriverAdapter,
+} from "./optimized-index.js";

--- a/src/optimized-index.ts
+++ b/src/optimized-index.ts
@@ -1,907 +1,999 @@
 import {
-  SqlDriverAdapter,
-  SqlQuery,
-  SqlResultSet,
-  Transaction,
-  ColumnTypeEnum,
-  ColumnType,
-  IsolationLevel,
+	SqlDriverAdapter,
+	SqlQuery,
+	SqlResultSet,
+	Transaction,
+	ColumnTypeEnum,
+	ColumnType,
+	IsolationLevel,
 } from "@prisma/driver-adapter-utils";
 
 export interface BunPostgresConfig {
-  connectionString: string;
-  maxConnections?: number;
-  idleTimeout?: number;
-  ssl?:
-    | boolean
-    | {
-        rejectUnauthorized?: boolean;
-        ca?: string;
-        cert?: string;
-        key?: string;
-      };
+	connectionString: string;
+	maxConnections?: number;
+	idleTimeout?: number;
+	ssl?:
+		| boolean
+		| {
+				rejectUnauthorized?: boolean;
+				ca?: string;
+				cert?: string;
+				key?: string;
+		  };
 }
 
 interface BunSqlResult extends Array<any> {
-  count: number;
-  command: string;
-  lastInsertRowid: number | null;
-  affectedRows: number | null;
+	count: number;
+	command: string;
+	lastInsertRowid: number | null;
+	affectedRows: number | null;
 }
 
 interface BunSqlConnection {
-  (strings: TemplateStringsArray, ...values: any[]): Promise<BunSqlResult>;
-  close(): Promise<void>;
-  end(): Promise<void>;
-  begin(): Promise<BunSqlTransaction>;
-  transaction<T>(callback: (tx: BunSqlTransaction) => Promise<T>): Promise<T>;
-  reserve(): Promise<BunReservedSqlConnection>;
+	(strings: TemplateStringsArray, ...values: any[]): Promise<BunSqlResult>;
+	close(): Promise<void>;
+	end(): Promise<void>;
+	begin(): Promise<BunSqlTransaction>;
+	transaction<T>(callback: (tx: BunSqlTransaction) => Promise<T>): Promise<T>;
+	reserve(): Promise<BunReservedSqlConnection>;
 }
 
 interface BunSqlTransaction {
-  (strings: TemplateStringsArray, ...values: any[]): Promise<BunSqlResult>;
-  commit(): Promise<void>;
-  rollback(): Promise<void>;
+	(strings: TemplateStringsArray, ...values: any[]): Promise<BunSqlResult>;
+	commit(): Promise<void>;
+	rollback(): Promise<void>;
 }
 
 interface BunReservedSqlConnection {
-  (strings: TemplateStringsArray, ...values: any[]): Promise<BunSqlResult>;
-  release?: () => Promise<void> | void;
+	(strings: TemplateStringsArray, ...values: any[]): Promise<BunSqlResult>;
+	release?: () => Promise<void> | void;
 }
 
 // Cache for template strings to avoid repeated parsing
 const templateCache = new Map<
-  string,
-  { strings: TemplateStringsArray; paramCount: number; argOrder: number[] }
+	string,
+	{ strings: TemplateStringsArray; paramCount: number; argOrder: number[] }
 >();
 
 // Pre-compiled column type matchers for better performance
 const DATE_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 const DATETIME_REGEX = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/;
 const UUID_REGEX =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+	/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
 export class OptimizedBunPostgresDriverAdapter implements SqlDriverAdapter {
-  readonly provider = "postgres" as const;
-  readonly adapterName = "bun-postgres-adapter-optimized";
-  private connectionString: string;
-  private connections: BunSqlConnection[] = [];
-  private availableConnections: BunSqlConnection[] = [];
-  private waitQueue: Array<{ resolve: (conn: BunSqlConnection) => void; reject: (err: Error) => void }> = [];
-  private maxConnections: number;
-
-  constructor(connectionString: string, maxConnections: number = 20) {
-    this.connectionString = connectionString;
-    this.maxConnections = maxConnections;
-  }
-
-  private async getConnection(): Promise<BunSqlConnection> {
-    // Try to get an available connection first
-    if (this.availableConnections.length > 0) {
-      return this.availableConnections.pop()!;
-    }
-
-    // If we haven't reached the max, create a new connection
-    if (this.connections.length < this.maxConnections) {
-      const connection = await this.createConnection();
-      this.connections.push(connection);
-      return connection;
-    }
-
-    // Wait for a connection to become available
-    return new Promise((resolve, reject) => {
-      this.waitQueue.push({ resolve, reject });
-    });
-  }
-
-  private releaseConnection(connection: BunSqlConnection): void {
-    if (this.waitQueue.length > 0) {
-      const waiter = this.waitQueue.shift();
-      waiter?.resolve(connection);
-      return;
-    }
-    this.availableConnections.push(connection);
-  }
-
-  private async createConnection(): Promise<BunSqlConnection> {
-    const BunSQL = (globalThis as any).Bun?.sql;
-    if (!BunSQL) {
-      throw new Error(
-        "Bun's native SQL client is not available. Make sure you're running with Bun 1.3+"
-      );
-    }
-
-    const candidates = this.buildPgConnectionCandidates(this.connectionString);
-    let lastErr: any = null;
-    for (const candidate of candidates) {
-      try {
-        const conn = new BunSQL(candidate) as BunSqlConnection;
-        try {
-          const strings = this.createTemplateStrings(['SELECT 1']);
-          await conn(strings);
-          return conn;
-        } catch (warmErr: any) {
-          if (this.isPgAuthFailed(warmErr)) { lastErr = warmErr; continue; }
-          throw warmErr;
-        }
-      } catch (e: any) {
-        lastErr = e; continue;
-      }
-    }
-    if (lastErr && (lastErr instanceof URIError || (typeof lastErr?.message === 'string' && /uri/i.test(lastErr.message)))) {
-      throw new Error("Invalid DATABASE_URL/connectionString. Check URL shape; credentials are auto-encoded by the adapter.");
-    }
-    throw lastErr ?? new Error('Failed to establish Postgres connection');
-  }
-
-  private isPgAuthFailed(err: any): boolean {
-    const msg = String(err?.message ?? '').toLowerCase();
-    return msg.includes('password authentication failed') || msg.includes('28p01');
-  }
-
-  private buildPgConnectionCandidates(input: string): string[] {
-    const raw = String(input ?? '').trim();
-    const norm = (() => {
-      if (!raw) return raw;
-
-      // Heuristic: if unencoded reserved characters appear in userinfo, avoid WHATWG parsing
-      const schemeMatch = raw.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
-      const schemeFromRaw = schemeMatch?.[1];
-      const restFromRaw = schemeMatch ? raw.slice(schemeMatch[0].length) : '';
-      const atInRest = restFromRaw.lastIndexOf('@');
-      const userinfoCandidate = atInRest !== -1 ? restFromRaw.slice(0, atInRest) : '';
-      const hasUnencodedReserved = /[/?#]/.test(userinfoCandidate);
-
-      if (!hasUnencodedReserved) {
-        try {
-          const u = new URL(raw);
-          const scheme = u.protocol.replace(':', '');
-          if (["postgres", "postgresql"].includes(scheme)) {
-            // Avoid double-encoding: decode valid %HH triplets first, then encode
-            const decodeTriplets = (s: string) => s.replace(/%[0-9a-fA-F]{2}/g, (m) => {
-              try { return decodeURIComponent(m); } catch { return m; }
-            });
-            if (u.username) u.username = encodeURIComponent(decodeTriplets(u.username));
-            if (u.password) u.password = encodeURIComponent(decodeTriplets(u.password));
-            return u.toString();
-          }
-          return raw;
-        } catch {}
-      }
-
-      // Manual rewrite tolerant of unencoded reserved in userinfo
-      const m = raw.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
-      if (!m) return raw;
-      const scheme = m[1];
-      const rest = raw.slice(m[0].length);
-
-      const at = rest.lastIndexOf('@');
-      if (at === -1) return raw;
-      const userinfo = rest.slice(0, at);
-      const hostAndTail = rest.slice(at + 1);
-      let boundary = hostAndTail.length;
-      for (const sep of ['/', '?', '#']) {
-        const idx = hostAndTail.indexOf(sep);
-        if (idx !== -1 && idx < boundary) boundary = idx;
-      }
-      const hostport = hostAndTail.slice(0, boundary);
-      const tail = hostAndTail.slice(boundary);
-      const colon = userinfo.indexOf(':');
-      const userRaw = colon === -1 ? userinfo : userinfo.slice(0, colon);
-      const passRaw = colon === -1 ? '' : userinfo.slice(colon + 1);
-      const safeDecode = (s: string) => { try { return decodeURIComponent(s); } catch { return s; } };
-      const username = encodeURIComponent(safeDecode(userRaw));
-      const password = passRaw !== '' ? encodeURIComponent(safeDecode(passRaw)) : '';
-      const rebuiltAuthority = password ? `${username}:${password}@${hostport}` : `${username}@${hostport}`;
-      return `${scheme}://${rebuiltAuthority}${tail}`;
-    })();
-
-    const out: string[] = [];
-    if (norm) out.push(norm);
-    if (raw && raw !== norm) out.push(raw);
-    const qp = this.toPgPasswordQueryVariant(raw);
-    if (qp) out.push(qp);
-    return out;
-  }
-
-  private toPgPasswordQueryVariant(raw: string): string | null {
-    const m = raw.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
-    if (!m) return null;
-    const scheme = m[1];
-    if (!['postgres', 'postgresql'].includes(scheme)) return null;
-    const rest = raw.slice(m[0].length);
-    const at = rest.lastIndexOf('@');
-    if (at === -1) return null;
-    const userinfo = rest.slice(0, at);
-    const hostAndTail = rest.slice(at + 1);
-    let boundary = hostAndTail.length;
-    for (const sep of ['/', '?', '#']) {
-      const idx = hostAndTail.indexOf(sep);
-      if (idx !== -1 && idx < boundary) boundary = idx;
-    }
-    const hostport = hostAndTail.slice(0, boundary);
-    const tail = hostAndTail.slice(boundary);
-    const colon = userinfo.indexOf(':');
-    const userRaw = colon === -1 ? userinfo : userinfo.slice(0, colon);
-    const passRaw = colon === -1 ? '' : userinfo.slice(colon + 1);
-    if (!passRaw) return null;
-    const safeDecode = (s: string) => { try { return decodeURIComponent(s); } catch { return s; } };
-    const username = encodeURIComponent(safeDecode(userRaw));
-    const passwordRaw = safeDecode(passRaw);
-    let path = tail;
-    let existingQuery = '';
-    const qIdx = tail.indexOf('?');
-    if (qIdx !== -1) {
-      path = tail.slice(0, qIdx);
-      existingQuery = tail.slice(qIdx + 1);
-    }
-    const join = existingQuery ? '&' : '?';
-    const finalQuery = `${existingQuery ? '?' + existingQuery : ''}${join}password=${encodeURIComponent(passwordRaw)}`;
-    return `${scheme}://${username}@${hostport}${path}${finalQuery}`;
-  }
-
-  async dispose(): Promise<void> {
-    // Close all connections in parallel
-    await Promise.all(this.connections.map((conn) => conn.end()));
-    this.connections = [];
-    this.availableConnections = [];
-    if (this.waitQueue.length > 0) {
-      const error = new Error("Adapter disposed");
-      while (this.waitQueue.length) {
-        this.waitQueue.shift()?.reject(error);
-      }
-    }
-    templateCache.clear();
-  }
-
-  async executeScript(script: string): Promise<void> {
-    const connection = await this.getConnection();
-    try {
-      const statements = script.split(";").filter((stmt) => stmt.trim());
-      for (const statement of statements) {
-        if (statement.trim()) {
-          const strings = this.createTemplateStrings([statement.trim()]);
-          await connection(strings);
-        }
-      }
-    } finally {
-      this.releaseConnection(connection);
-    }
-  }
-
-  async queryRaw(query: SqlQuery): Promise<SqlResultSet> {
-    const connection = await this.getConnection();
-    try {
-      const result = await this.executeQueryOptimized(
-        connection,
-        query.sql,
-        query.args || []
-      );
-
-      // Fast path for empty results
-      if (!Array.isArray(result) || result.length === 0) {
-        return { columnNames: [], columnTypes: [], rows: [] };
-      }
-
-      // Pre-allocate arrays for better performance
-      const firstRow = result[0];
-      const columnNames = Object.keys(firstRow);
-      const columnCount = columnNames.length;
-      const rowCount = result.length;
-
-      // Determine column types using a scan to better detect JSON columns
-      const columnTypes = this.determineColumnTypes(result, columnNames);
-      const rows = new Array(rowCount);
-
-      // Process all rows efficiently
-      for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-        const row = result[rowIndex];
-        const processedRow = new Array(columnCount);
-
-        for (let colIndex = 0; colIndex < columnCount; colIndex++) {
-          const val = row[columnNames[colIndex]];
-          processedRow[colIndex] =
-            columnTypes[colIndex] === ColumnTypeEnum.Json
-              ? this.ensureJsonString(val)
-              : this.serializeValueFast(val);
-        }
-
-        rows[rowIndex] = processedRow;
-      }
-
-      return { columnNames, columnTypes, rows };
-    } finally {
-      this.releaseConnection(connection);
-    }
-  }
-
-  async executeRaw(query: SqlQuery): Promise<number> {
-    const connection = await this.getConnection();
-    try {
-      const result = await this.executeQueryOptimized(
-        connection,
-        query.sql,
-        query.args || []
-      );
-      return result.affectedRows || result.count || 0;
-    } catch (error) {
-      throw new Error(error instanceof Error ? error.message : String(error));
-    } finally {
-      this.releaseConnection(connection);
-    }
-  }
-
-  private executeQueryOptimized(
-    connection: BunSqlConnection,
-    sql: string,
-    args: any[]
-  ): Promise<BunSqlResult> {
-    // Fast path for queries without parameters
-    if (args.length === 0) {
-      const strings = this.createTemplateStrings([sql]);
-      return connection(strings);
-    }
-
-    const cached = this.getOrCreateTemplate(sql, args.length)!;
-    const expanded = cached.argOrder?.length
-      ? cached.argOrder.map((i) => args[i])
-      : args;
-    const coerced = this.coerceArgsForPostgres(expanded);
-    return connection(cached.strings, ...coerced);
-  }
-
-  private createTemplateStrings(parts: string[]): TemplateStringsArray {
-    // Ensure we have at least one empty string at the end
-    if (parts.length === 1) {
-      parts = [...parts, ""];
-    }
-    return Object.assign(parts, { raw: parts }) as TemplateStringsArray;
-  }
-  
-  // Convert primitive JS arrays to a Postgres array literal string.
-  // This helps when binding values into array-typed columns (e.g., text[]),
-  // preventing errors like: malformed array literal: "...".
-  // We keep object/complex arrays untouched to avoid interfering with JSON.
-  private coerceArgsForPostgres(args: any[]): any[] {
-    const toPgArrayLiteral = (arr: any[]): string => {
-      const encodeItem = (v: any): string => {
-        if (v === null || v === undefined) return 'NULL';
-        switch (typeof v) {
-          case 'number':
-            return Number.isFinite(v) ? String(v) : 'NULL';
-          case 'boolean':
-            return v ? 'true' : 'false';
-          case 'string': {
-            const s = v.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-            return `"${s}"`;
-          }
-          default: {
-            try {
-              const s = JSON.stringify(v);
-              const e = s.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-              return `"${e}"`;
-            } catch {
-              return 'NULL';
-            }
-          }
-        }
-      };
-      return `{${arr.map(encodeItem).join(',')}}`;
-    };
-
-    const isPrimitiveArray = (a: any[]): boolean =>
-      Array.isArray(a) && a.every((v) => v === null || ['string', 'number', 'boolean'].includes(typeof v));
-
-    return args.map((v) => (Array.isArray(v) && isPrimitiveArray(v) ? toPgArrayLiteral(v) : v));
-  }
-
-  private getOrCreateTemplate(sql: string, argCount: number) {
-    if (argCount === 0) {
-      return null;
-    }
-
-    const cacheKey = sql;
-    let cached = templateCache.get(cacheKey);
-
-    if (!cached || cached.paramCount !== argCount) {
-      const built = this.buildTemplate(sql, argCount);
-      if (!built) {
-        throw new Error(
-          "Query arguments were provided but no SQL placeholders were found outside of literals/comments."
-        );
-      }
-      templateCache.set(cacheKey, built);
-      cached = built;
-    }
-
-    return cached;
-  }
-
-  private buildTemplate(sql: string, argCount: number) {
-    const templateSql = this.replacePlaceholders(sql, argCount);
-    if (!templateSql) {
-      return null;
-    }
-
-    const parts = templateSql.split(/\$\{\d+\}/);
-    const strings = this.createTemplateStrings(parts);
-    const argOrder: number[] = [];
-    const re = /\$\{(\d+)\}/g;
-    let match: RegExpExecArray | null;
-    while ((match = re.exec(templateSql)) !== null) {
-      argOrder.push(Number(match[1]));
-    }
-    return { strings, paramCount: argCount, argOrder };
-  }
-
-  private replacePlaceholders(sql: string, argCount: number): string | null {
-    if (argCount === 0) {
-      return sql;
-    }
-
-    if (/\$\d+/.test(sql)) {
-      return this.replaceDollarPlaceholders(sql, argCount);
-    }
-
-    if (sql.includes("?")) {
-      return this.replaceQuestionPlaceholders(sql, argCount);
-    }
-
-    return null;
-  }
-
-  private replaceDollarPlaceholders(sql: string, argCount: number): string {
-    let templateSql = sql;
-    for (let n = argCount; n >= 1; n--) {
-      const idx = n - 1;
-      const marker = '${' + idx + '}';
-      templateSql = templateSql.replaceAll(`$${n}`, marker);
-    }
-    return templateSql;
-  }
-
-  private replaceQuestionPlaceholders(sql: string, argCount: number): string | null {
-    let result = "";
-    let lastIndex = 0;
-    let replaced = 0;
-    let i = 0;
-    let inSingle = false;
-    let inDouble = false;
-    let inLineComment = false;
-    let inBlockComment = false;
-    let dollarTag: string | null = null;
-
-    while (i < sql.length) {
-      const char = sql[i];
-      const next = sql[i + 1];
-
-      if (inLineComment) {
-        if (char === "\n") {
-          inLineComment = false;
-        }
-        i++;
-        continue;
-      }
-
-      if (inBlockComment) {
-        if (char === "*" && next === "/") {
-          inBlockComment = false;
-          i += 2;
-          continue;
-        }
-        i++;
-        continue;
-      }
-
-      if (dollarTag) {
-        if (sql.startsWith(dollarTag, i)) {
-          i += dollarTag.length;
-          dollarTag = null;
-          continue;
-        }
-        i++;
-        continue;
-      }
-
-      if (inSingle) {
-        if (char === "'" && next === "'") {
-          i += 2;
-          continue;
-        }
-        if (char === "'") {
-          inSingle = false;
-        }
-        i++;
-        continue;
-      }
-
-      if (inDouble) {
-        if (char === '"' && next === '"') {
-          i += 2;
-          continue;
-        }
-        if (char === '"') {
-          inDouble = false;
-        }
-        i++;
-        continue;
-      }
-
-      if (char === "'" && !inDouble) {
-        inSingle = true;
-        i++;
-        continue;
-      }
-
-      if (char === '"' && !inSingle) {
-        inDouble = true;
-        i++;
-        continue;
-      }
-
-      if (char === "-" && next === "-") {
-        inLineComment = true;
-        i += 2;
-        continue;
-      }
-
-      if (char === "/" && next === "*") {
-        inBlockComment = true;
-        i += 2;
-        continue;
-      }
-
-      if (char === "$") {
-        const match = sql.slice(i).match(/^\$[A-Za-z0-9_]*\$/);
-        if (match) {
-          dollarTag = match[0];
-          i += match[0].length;
-          continue;
-        }
-      }
-
-      if (char === "?" && replaced < argCount) {
-        result += sql.slice(lastIndex, i) + "${" + replaced + "}";
-        replaced++;
-        i++;
-        lastIndex = i;
-        continue;
-      }
-
-      i++;
-    }
-
-    result += sql.slice(lastIndex);
-    if (replaced !== argCount) {
-      return null;
-    }
-    return result;
-  }
-
-  async startTransaction(
-    isolationLevel?: IsolationLevel
-  ): Promise<Transaction> {
-    const connection = await this.getConnection();
-    let reserved: BunReservedSqlConnection;
-
-    try {
-      reserved = await connection.reserve();
-    } catch (err) {
-      this.releaseConnection(connection);
-      throw err;
-    }
-
-    const txRunner = ((strings: TemplateStringsArray, ...values: any[]) =>
-      reserved(strings, ...values)) as BunSqlTransaction;
-
-    txRunner.commit = async () => {
-      const commit = this.createTemplateStrings(["COMMIT"]);
-      await reserved(commit);
-    };
-
-    txRunner.rollback = async () => {
-      const rollback = this.createTemplateStrings(["ROLLBACK"]);
-      await reserved(rollback);
-    };
-
-    let finished = false;
-    let aborted = false;
-
-    const releaseReserved = async () => {
-      try {
-        const maybeRelease = reserved.release?.();
-        if (maybeRelease && typeof (maybeRelease as any).then === "function") {
-          await maybeRelease;
-        }
-      } catch {
-        // ignore release errors
-      }
-    };
-
-    const finalize = async (action: "commit" | "rollback") => {
-      if (finished) {
-        return;
-      }
-
-      finished = true;
-      try {
-        if (action === "commit") {
-          await txRunner.commit();
-        } else {
-          try {
-            await txRunner.rollback();
-          } catch {
-            // swallow rollback errors for already-closed transactions
-          }
-        }
-      } finally {
-        await releaseReserved();
-        this.releaseConnection(connection);
-      }
-    };
-
-    try {
-      const begin = this.createTemplateStrings(["BEGIN"]);
-      await reserved(begin);
-
-      if (isolationLevel) {
-        const iso = this.createTemplateStrings([
-          `SET TRANSACTION ISOLATION LEVEL ${isolationLevel}`,
-        ]);
-        await reserved(iso);
-      }
-    } catch (err) {
-      await releaseReserved();
-      this.releaseConnection(connection);
-      throw err;
-    }
-
-    const runQuery = async (sql: string, args: any[]): Promise<BunSqlResult> => {
-      if (finished) {
-        throw new Error("Transaction is already closed");
-      }
-
-      try {
-        return await this.executeTransactionQueryOptimized(
-          txRunner,
-          sql,
-          args,
-        );
-      } catch (err) {
-        aborted = true;
-        throw err;
-      }
-    };
-
-    return {
-      provider: this.provider,
-      adapterName: this.adapterName,
-      options: {
-        usePhantomQuery: false,
-      },
-      queryRaw: async (query: SqlQuery) => {
-        const result = await runQuery(query.sql, query.args || []);
-
-        if (!Array.isArray(result) || result.length === 0) {
-          return { columnNames: [], columnTypes: [], rows: [] };
-        }
-
-        const firstRow = result[0];
-        const columnNames = Object.keys(firstRow);
-        const columnCount = columnNames.length;
-
-        const columnTypes = this.determineColumnTypes(result, columnNames);
-        const rows = new Array(result.length);
-
-        for (let rowIndex = 0; rowIndex < result.length; rowIndex++) {
-          const row = result[rowIndex];
-          const processedRow = new Array(columnCount);
-
-          for (let colIndex = 0; colIndex < columnCount; colIndex++) {
-            const val = row[columnNames[colIndex]];
-            processedRow[colIndex] =
-              columnTypes[colIndex] === ColumnTypeEnum.Json
-                ? this.ensureJsonString(val)
-                : this.serializeValueFast(val);
-          }
-
-          rows[rowIndex] = processedRow;
-        }
-
-        return { columnNames, columnTypes, rows };
-      },
-      executeRaw: async (query: SqlQuery) => {
-        const result = await runQuery(query.sql, query.args || []);
-        return result.affectedRows || result.count || 0;
-      },
-      commit: async () => {
-        if (aborted) {
-          await finalize("rollback");
-          throw new Error("Transaction rolled back due to a previous error");
-        }
-        await finalize("commit");
-      },
-      rollback: async () => {
-        await finalize("rollback");
-      },
-    };
-  }
-
-  private executeTransactionQueryOptimized(
-    tx: BunSqlTransaction,
-    sql: string,
-    args: any[]
-  ): Promise<BunSqlResult> {
-    if (args.length === 0) {
-      const strings = this.createTemplateStrings([sql]);
-      return tx(strings);
-    }
-
-    const cached = this.getOrCreateTemplate(sql, args.length)!;
-    const expanded = cached.argOrder?.length
-      ? cached.argOrder.map((i) => args[i])
-      : args;
-    const coerced = this.coerceArgsForPostgres(expanded);
-    return tx(cached.strings, ...coerced);
-  }
-
-  private inferColumnTypeFast(value: unknown): ColumnType {
-    if (value === null || value === undefined) {
-      return ColumnTypeEnum.UnknownNumber;
-    }
-
-    const valueType = typeof value;
-
-    // Fast type checking - most common cases first
-    switch (valueType) {
-      case "boolean":
-        return ColumnTypeEnum.Boolean;
-      case "number":
-        return Number.isInteger(value)
-          ? ColumnTypeEnum.Int32
-          : ColumnTypeEnum.Double;
-      case "bigint":
-        return ColumnTypeEnum.Int64;
-      case "string":
-        // Fast string type detection
-        if (DATETIME_REGEX.test(value as string)) {
-          return ColumnTypeEnum.DateTime;
-        }
-        if (DATE_REGEX.test(value as string)) {
-          return ColumnTypeEnum.Date;
-        }
-        if (UUID_REGEX.test(value as string)) {
-          return ColumnTypeEnum.Uuid;
-        }
-        return ColumnTypeEnum.Text;
-      case "object":
-        if (value instanceof Date) {
-          return ColumnTypeEnum.DateTime;
-        }
-        if (Buffer.isBuffer(value)) {
-          return ColumnTypeEnum.Bytes;
-        }
-        return ColumnTypeEnum.Json;
-      default:
-        return ColumnTypeEnum.UnknownNumber;
-    }
-  }
-
-  private serializeValueFast(value: unknown): unknown {
-    if (value === null || value === undefined) {
-      return value;
-    }
-
-    const valueType = typeof value;
-
-    // Fast path for common types
-    if (
-      valueType === "string" ||
-      valueType === "number" ||
-      valueType === "boolean"
-    ) {
-      return value;
-    }
-
-    if (valueType === "bigint") {
-      return value.toString();
-    }
-
-    if (value instanceof Date) {
-      return value.toISOString();
-    }
-
-    if (Buffer.isBuffer(value)) {
-      return value;
-    }
-
-    // Ensure JSON columns arrive as valid JSON strings
-    try {
-      return JSON.stringify(value);
-    } catch {
-      return String(value);
-    }
-  }
-
-  private determineColumnTypes(result: any[], columnNames: string[]): ColumnType[] {
-    const columnCount = columnNames.length;
-    const types = new Array(columnCount) as ColumnType[];
-    for (let i = 0; i < columnCount; i++) {
-      const name = columnNames[i];
-      let isJson = false;
-      for (let r = 0; r < result.length; r++) {
-        const v = result[r][name];
-        if (v === null || v === undefined) continue;
-        const t = typeof v;
-        if (t === 'object') {
-          if (v instanceof Date || Buffer.isBuffer(v)) {
-            // not JSON
-          } else {
-            isJson = true; break;
-          }
-        } else if (t === 'string') {
-          const s = (v as string).trim();
-          if (this.isJsonishString(s)) { isJson = true; break; }
-        }
-      }
-      if (isJson) types[i] = ColumnTypeEnum.Json;
-      else types[i] = this.inferColumnTypeFast(result[0]?.[name]);
-    }
-    return types;
-  }
-
-  private isJsonishString(s: string): boolean {
-    if (!s) return false;
-    const t = s.trim();
-    if (!t) return false;
-    if (t.startsWith('{') || t.startsWith('[')) return true;
-    if (t.startsWith('"') && t.endsWith('"')) return true;
-    return false;
-  }
-
-  private ensureJsonString(value: unknown): string {
-    if (value === null || value === undefined) return 'null';
-    const t = typeof value;
-    if (t === 'string') {
-      const s = value as string;
-      return this.isJsonishString(s) ? s : JSON.stringify(s);
-    }
-    if (t === 'number' || t === 'boolean') return JSON.stringify(value);
-    if (value instanceof Date) return JSON.stringify(value.toISOString());
-    if (Buffer.isBuffer(value)) return JSON.stringify(Array.from(value as unknown as Uint8Array));
-    try { return JSON.stringify(value); } catch { return 'null'; }
-  }
+	readonly provider = "postgres" as const;
+	readonly adapterName = "bun-postgres-adapter-optimized";
+	private connectionString: string;
+	private connections: BunSqlConnection[] = [];
+	private availableConnections: BunSqlConnection[] = [];
+	private waitQueue: Array<{
+		resolve: (conn: BunSqlConnection) => void;
+		reject: (err: Error) => void;
+	}> = [];
+	private maxConnections: number;
+
+	constructor(connectionString: string, maxConnections: number = 20) {
+		this.connectionString = connectionString;
+		this.maxConnections = maxConnections;
+	}
+
+	private async getConnection(): Promise<BunSqlConnection> {
+		// Try to get an available connection first
+		if (this.availableConnections.length > 0) {
+			return this.availableConnections.pop()!;
+		}
+
+		// If we haven't reached the max, create a new connection
+		if (this.connections.length < this.maxConnections) {
+			const connection = await this.createConnection();
+			this.connections.push(connection);
+			return connection;
+		}
+
+		// Wait for a connection to become available
+		return new Promise((resolve, reject) => {
+			this.waitQueue.push({ resolve, reject });
+		});
+	}
+
+	private releaseConnection(connection: BunSqlConnection): void {
+		if (this.waitQueue.length > 0) {
+			const waiter = this.waitQueue.shift();
+			waiter?.resolve(connection);
+			return;
+		}
+		this.availableConnections.push(connection);
+	}
+
+	private async createConnection(): Promise<BunSqlConnection> {
+		const BunSQL = (globalThis as any).Bun?.sql;
+		if (!BunSQL) {
+			throw new Error(
+				"Bun's native SQL client is not available. Make sure you're running with Bun 1.3+",
+			);
+		}
+
+		const candidates = this.buildPgConnectionCandidates(this.connectionString);
+		let lastErr: any = null;
+		for (const candidate of candidates) {
+			try {
+				const conn = new BunSQL(candidate) as BunSqlConnection;
+				try {
+					const strings = this.createTemplateStrings(["SELECT 1"]);
+					await conn(strings);
+					return conn;
+				} catch (warmErr: any) {
+					if (this.isPgAuthFailed(warmErr)) {
+						lastErr = warmErr;
+						continue;
+					}
+					throw warmErr;
+				}
+			} catch (e: any) {
+				lastErr = e;
+				continue;
+			}
+		}
+		if (
+			lastErr &&
+			(lastErr instanceof URIError ||
+				(typeof lastErr?.message === "string" && /uri/i.test(lastErr.message)))
+		) {
+			throw new Error(
+				"Invalid DATABASE_URL/connectionString. Check URL shape; credentials are auto-encoded by the adapter.",
+			);
+		}
+		throw lastErr ?? new Error("Failed to establish Postgres connection");
+	}
+
+	private isPgAuthFailed(err: any): boolean {
+		const msg = String(err?.message ?? "").toLowerCase();
+		return (
+			msg.includes("password authentication failed") || msg.includes("28p01")
+		);
+	}
+
+	private buildPgConnectionCandidates(input: string): string[] {
+		const raw = String(input ?? "").trim();
+		const norm = (() => {
+			if (!raw) return raw;
+
+			// Heuristic: if unencoded reserved characters appear in userinfo, avoid WHATWG parsing
+			const schemeMatch = raw.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
+			const schemeFromRaw = schemeMatch?.[1];
+			const restFromRaw = schemeMatch ? raw.slice(schemeMatch[0].length) : "";
+			const atInRest = restFromRaw.lastIndexOf("@");
+			const userinfoCandidate =
+				atInRest !== -1 ? restFromRaw.slice(0, atInRest) : "";
+			const hasUnencodedReserved = /[/?#]/.test(userinfoCandidate);
+
+			if (!hasUnencodedReserved) {
+				try {
+					const u = new URL(raw);
+					const scheme = u.protocol.replace(":", "");
+					if (["postgres", "postgresql"].includes(scheme)) {
+						// Avoid double-encoding: decode valid %HH triplets first, then encode
+						const decodeTriplets = (s: string) =>
+							s.replace(/%[0-9a-fA-F]{2}/g, (m) => {
+								try {
+									return decodeURIComponent(m);
+								} catch {
+									return m;
+								}
+							});
+						if (u.username)
+							u.username = encodeURIComponent(decodeTriplets(u.username));
+						if (u.password)
+							u.password = encodeURIComponent(decodeTriplets(u.password));
+						return u.toString();
+					}
+					return raw;
+				} catch {}
+			}
+
+			// Manual rewrite tolerant of unencoded reserved in userinfo
+			const m = raw.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
+			if (!m) return raw;
+			const scheme = m[1];
+			const rest = raw.slice(m[0].length);
+
+			const at = rest.lastIndexOf("@");
+			if (at === -1) return raw;
+			const userinfo = rest.slice(0, at);
+			const hostAndTail = rest.slice(at + 1);
+			let boundary = hostAndTail.length;
+			for (const sep of ["/", "?", "#"]) {
+				const idx = hostAndTail.indexOf(sep);
+				if (idx !== -1 && idx < boundary) boundary = idx;
+			}
+			const hostport = hostAndTail.slice(0, boundary);
+			const tail = hostAndTail.slice(boundary);
+			const colon = userinfo.indexOf(":");
+			const userRaw = colon === -1 ? userinfo : userinfo.slice(0, colon);
+			const passRaw = colon === -1 ? "" : userinfo.slice(colon + 1);
+			const safeDecode = (s: string) => {
+				try {
+					return decodeURIComponent(s);
+				} catch {
+					return s;
+				}
+			};
+			const username = encodeURIComponent(safeDecode(userRaw));
+			const password =
+				passRaw !== "" ? encodeURIComponent(safeDecode(passRaw)) : "";
+			const rebuiltAuthority = password
+				? `${username}:${password}@${hostport}`
+				: `${username}@${hostport}`;
+			return `${scheme}://${rebuiltAuthority}${tail}`;
+		})();
+
+		const out: string[] = [];
+		if (norm) out.push(norm);
+		if (raw && raw !== norm) out.push(raw);
+		const qp = this.toPgPasswordQueryVariant(raw);
+		if (qp) out.push(qp);
+		return out;
+	}
+
+	private toPgPasswordQueryVariant(raw: string): string | null {
+		const m = raw.match(/^([a-zA-Z][a-zA-Z0-9+.-]*):\/\//);
+		if (!m) return null;
+		const scheme = m[1];
+		if (!["postgres", "postgresql"].includes(scheme)) return null;
+		const rest = raw.slice(m[0].length);
+		const at = rest.lastIndexOf("@");
+		if (at === -1) return null;
+		const userinfo = rest.slice(0, at);
+		const hostAndTail = rest.slice(at + 1);
+		let boundary = hostAndTail.length;
+		for (const sep of ["/", "?", "#"]) {
+			const idx = hostAndTail.indexOf(sep);
+			if (idx !== -1 && idx < boundary) boundary = idx;
+		}
+		const hostport = hostAndTail.slice(0, boundary);
+		const tail = hostAndTail.slice(boundary);
+		const colon = userinfo.indexOf(":");
+		const userRaw = colon === -1 ? userinfo : userinfo.slice(0, colon);
+		const passRaw = colon === -1 ? "" : userinfo.slice(colon + 1);
+		if (!passRaw) return null;
+		const safeDecode = (s: string) => {
+			try {
+				return decodeURIComponent(s);
+			} catch {
+				return s;
+			}
+		};
+		const username = encodeURIComponent(safeDecode(userRaw));
+		const passwordRaw = safeDecode(passRaw);
+		let path = tail;
+		let existingQuery = "";
+		const qIdx = tail.indexOf("?");
+		if (qIdx !== -1) {
+			path = tail.slice(0, qIdx);
+			existingQuery = tail.slice(qIdx + 1);
+		}
+		const join = existingQuery ? "&" : "?";
+		const finalQuery = `${existingQuery ? "?" + existingQuery : ""}${join}password=${encodeURIComponent(passwordRaw)}`;
+		return `${scheme}://${username}@${hostport}${path}${finalQuery}`;
+	}
+
+	async dispose(): Promise<void> {
+		// Close all connections in parallel
+		await Promise.all(this.connections.map((conn) => conn.end()));
+		this.connections = [];
+		this.availableConnections = [];
+		if (this.waitQueue.length > 0) {
+			const error = new Error("Adapter disposed");
+			while (this.waitQueue.length) {
+				this.waitQueue.shift()?.reject(error);
+			}
+		}
+		templateCache.clear();
+	}
+
+	async executeScript(script: string): Promise<void> {
+		const connection = await this.getConnection();
+		try {
+			const statements = script.split(";").filter((stmt) => stmt.trim());
+			for (const statement of statements) {
+				if (statement.trim()) {
+					const strings = this.createTemplateStrings([statement.trim()]);
+					await connection(strings);
+				}
+			}
+		} finally {
+			this.releaseConnection(connection);
+		}
+	}
+
+	async queryRaw(query: SqlQuery): Promise<SqlResultSet> {
+		const connection = await this.getConnection();
+		try {
+			const result = await this.executeQueryOptimized(
+				connection,
+				query.sql,
+				query.args || [],
+			);
+
+			// Fast path for empty results
+			if (!Array.isArray(result) || result.length === 0) {
+				return { columnNames: [], columnTypes: [], rows: [] };
+			}
+
+			// Pre-allocate arrays for better performance
+			const firstRow = result[0];
+			const columnNames = Object.keys(firstRow);
+			const columnCount = columnNames.length;
+			const rowCount = result.length;
+
+			// Determine column types using a scan to better detect JSON columns
+			const columnTypes = this.determineColumnTypes(result, columnNames);
+			const rows = new Array(rowCount);
+
+			// Process all rows efficiently
+			for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+				const row = result[rowIndex];
+				const processedRow = new Array(columnCount);
+
+				for (let colIndex = 0; colIndex < columnCount; colIndex++) {
+					const val = row[columnNames[colIndex]];
+					processedRow[colIndex] =
+						columnTypes[colIndex] === ColumnTypeEnum.Json
+							? this.ensureJsonString(val)
+							: this.serializeValueFast(val);
+				}
+
+				rows[rowIndex] = processedRow;
+			}
+
+			return { columnNames, columnTypes, rows };
+		} finally {
+			this.releaseConnection(connection);
+		}
+	}
+
+	async executeRaw(query: SqlQuery): Promise<number> {
+		const connection = await this.getConnection();
+		try {
+			const result = await this.executeQueryOptimized(
+				connection,
+				query.sql,
+				query.args || [],
+			);
+			return result.affectedRows || result.count || 0;
+		} catch (error) {
+			throw new Error(error instanceof Error ? error.message : String(error));
+		} finally {
+			this.releaseConnection(connection);
+		}
+	}
+
+	private executeQueryOptimized(
+		connection: BunSqlConnection,
+		sql: string,
+		args: any[],
+	): Promise<BunSqlResult> {
+		// Fast path for queries without parameters
+		if (args.length === 0) {
+			const strings = this.createTemplateStrings([sql]);
+			return connection(strings);
+		}
+
+		const cached = this.getOrCreateTemplate(sql, args.length);
+		if (cached) {
+			const expanded = cached.argOrder?.length
+				? cached.argOrder.map((i) => args[i])
+				: args;
+			const coerced = this.coerceArgsForPostgres(expanded);
+			return connection(cached.strings, ...coerced);
+		}
+
+		// Fallback: Query has args but no recognized placeholders
+		// This can happen with Prisma-generated queries that embed parameters differently
+		// We still need to coerce arrays for Postgres compatibility
+		const coerced = this.coerceArgsForPostgres(args);
+		const strings = this.createTemplateStrings([sql]);
+		return connection(strings, ...coerced);
+	}
+
+	private createTemplateStrings(parts: string[]): TemplateStringsArray {
+		// Ensure we have at least one empty string at the end
+		if (parts.length === 1) {
+			parts = [...parts, ""];
+		}
+		return Object.assign(parts, { raw: parts }) as TemplateStringsArray;
+	}
+
+	// Convert primitive JS arrays to a Postgres array literal string.
+	// This helps when binding values into array-typed columns (e.g., text[]),
+	// preventing errors like: malformed array literal: "...".
+	// We keep object/complex arrays untouched to avoid interfering with JSON.
+	private coerceArgsForPostgres(args: any[]): any[] {
+		const toPgArrayLiteral = (arr: any[]): string => {
+			const encodeItem = (v: any): string => {
+				if (v === null || v === undefined) return "NULL";
+				switch (typeof v) {
+					case "number":
+						return Number.isFinite(v) ? String(v) : "NULL";
+					case "boolean":
+						return v ? "true" : "false";
+					case "string": {
+						const s = v.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+						return `"${s}"`;
+					}
+					default: {
+						try {
+							const s = JSON.stringify(v);
+							const e = s.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+							return `"${e}"`;
+						} catch {
+							return "NULL";
+						}
+					}
+				}
+			};
+			return `{${arr.map(encodeItem).join(",")}}`;
+		};
+
+		const isPrimitiveArray = (a: any[]): boolean =>
+			Array.isArray(a) &&
+			a.every(
+				(v) => v === null || ["string", "number", "boolean"].includes(typeof v),
+			);
+
+		return args.map((v) =>
+			Array.isArray(v) && isPrimitiveArray(v) ? toPgArrayLiteral(v) : v,
+		);
+	}
+
+	private getOrCreateTemplate(sql: string, argCount: number) {
+		if (argCount === 0) {
+			return null;
+		}
+
+		const cacheKey = sql;
+		let cached = templateCache.get(cacheKey);
+
+		if (!cached || cached.paramCount !== argCount) {
+			const built = this.buildTemplate(sql, argCount);
+			if (!built) {
+				// Don't throw - return null to allow fallback path
+				// This handles Prisma queries that embed parameters differently
+				return null;
+			}
+			templateCache.set(cacheKey, built);
+			cached = built;
+		}
+
+		return cached;
+	}
+
+	private buildTemplate(sql: string, argCount: number) {
+		const templateSql = this.replacePlaceholders(sql, argCount);
+		if (!templateSql) {
+			return null;
+		}
+
+		const parts = templateSql.split(/\$\{\d+\}/);
+		const strings = this.createTemplateStrings(parts);
+		const re = /\$\{(\d+)\}/g;
+		const argOrder: number[] = [];
+		let m: RegExpExecArray | null = re.exec(templateSql);
+		while (m !== null) {
+			argOrder.push(Number(m[1]));
+			m = re.exec(templateSql);
+		}
+		return { strings, paramCount: argCount, argOrder };
+	}
+
+	private replacePlaceholders(sql: string, argCount: number): string | null {
+		if (argCount === 0) {
+			return sql;
+		}
+
+		if (/\$\d+/.test(sql)) {
+			return this.replaceDollarPlaceholders(sql, argCount);
+		}
+
+		if (sql.includes("?")) {
+			return this.replaceQuestionPlaceholders(sql, argCount);
+		}
+
+		return null;
+	}
+
+	private replaceDollarPlaceholders(sql: string, argCount: number): string {
+		let templateSql = sql;
+		for (let n = argCount; n >= 1; n--) {
+			const idx = n - 1;
+			const marker = "${" + idx + "}";
+			templateSql = templateSql.replaceAll(`$${n}`, marker);
+		}
+		return templateSql;
+	}
+
+	private replaceQuestionPlaceholders(
+		sql: string,
+		argCount: number,
+	): string | null {
+		let result = "";
+		let lastIndex = 0;
+		let replaced = 0;
+		let i = 0;
+		let inSingle = false;
+		let inDouble = false;
+		let inLineComment = false;
+		let inBlockComment = false;
+		let dollarTag: string | null = null;
+
+		while (i < sql.length) {
+			const char = sql[i];
+			const next = sql[i + 1];
+
+			if (inLineComment) {
+				if (char === "\n") {
+					inLineComment = false;
+				}
+				i++;
+				continue;
+			}
+
+			if (inBlockComment) {
+				if (char === "*" && next === "/") {
+					inBlockComment = false;
+					i += 2;
+					continue;
+				}
+				i++;
+				continue;
+			}
+
+			if (dollarTag) {
+				if (sql.startsWith(dollarTag, i)) {
+					i += dollarTag.length;
+					dollarTag = null;
+					continue;
+				}
+				i++;
+				continue;
+			}
+
+			if (inSingle) {
+				if (char === "'" && next === "'") {
+					i += 2;
+					continue;
+				}
+				if (char === "'") {
+					inSingle = false;
+				}
+				i++;
+				continue;
+			}
+
+			if (inDouble) {
+				if (char === '"' && next === '"') {
+					i += 2;
+					continue;
+				}
+				if (char === '"') {
+					inDouble = false;
+				}
+				i++;
+				continue;
+			}
+
+			if (char === "'" && !inDouble) {
+				inSingle = true;
+				i++;
+				continue;
+			}
+
+			if (char === '"' && !inSingle) {
+				inDouble = true;
+				i++;
+				continue;
+			}
+
+			if (char === "-" && next === "-") {
+				inLineComment = true;
+				i += 2;
+				continue;
+			}
+
+			if (char === "/" && next === "*") {
+				inBlockComment = true;
+				i += 2;
+				continue;
+			}
+
+			if (char === "$") {
+				const match = sql.slice(i).match(/^\$[A-Za-z0-9_]*\$/);
+				if (match) {
+					dollarTag = match[0];
+					i += match[0].length;
+					continue;
+				}
+			}
+
+			if (char === "?" && replaced < argCount) {
+				result += sql.slice(lastIndex, i) + "${" + replaced + "}";
+				replaced++;
+				i++;
+				lastIndex = i;
+				continue;
+			}
+
+			i++;
+		}
+
+		result += sql.slice(lastIndex);
+		if (replaced !== argCount) {
+			return null;
+		}
+		return result;
+	}
+
+	async startTransaction(
+		isolationLevel?: IsolationLevel,
+	): Promise<Transaction> {
+		const connection = await this.getConnection();
+		let reserved: BunReservedSqlConnection;
+
+		try {
+			reserved = await connection.reserve();
+		} catch (err) {
+			this.releaseConnection(connection);
+			throw err;
+		}
+
+		const txRunner = ((strings: TemplateStringsArray, ...values: any[]) =>
+			reserved(strings, ...values)) as BunSqlTransaction;
+
+		txRunner.commit = async () => {
+			const commit = this.createTemplateStrings(["COMMIT"]);
+			await reserved(commit);
+		};
+
+		txRunner.rollback = async () => {
+			const rollback = this.createTemplateStrings(["ROLLBACK"]);
+			await reserved(rollback);
+		};
+
+		let finished = false;
+		let aborted = false;
+
+		const releaseReserved = async () => {
+			try {
+				const maybeRelease = reserved.release?.();
+				if (maybeRelease && typeof (maybeRelease as any).then === "function") {
+					await maybeRelease;
+				}
+			} catch {
+				// ignore release errors
+			}
+		};
+
+		const finalize = async (action: "commit" | "rollback") => {
+			if (finished) {
+				return;
+			}
+
+			finished = true;
+			try {
+				if (action === "commit") {
+					await txRunner.commit();
+				} else {
+					try {
+						await txRunner.rollback();
+					} catch {
+						// swallow rollback errors for already-closed transactions
+					}
+				}
+			} finally {
+				await releaseReserved();
+				this.releaseConnection(connection);
+			}
+		};
+
+		try {
+			const begin = this.createTemplateStrings(["BEGIN"]);
+			await reserved(begin);
+
+			if (isolationLevel) {
+				const iso = this.createTemplateStrings([
+					`SET TRANSACTION ISOLATION LEVEL ${isolationLevel}`,
+				]);
+				await reserved(iso);
+			}
+		} catch (err) {
+			await releaseReserved();
+			this.releaseConnection(connection);
+			throw err;
+		}
+
+		const runQuery = async (
+			sql: string,
+			args: any[],
+		): Promise<BunSqlResult> => {
+			if (finished) {
+				throw new Error("Transaction is already closed");
+			}
+
+			try {
+				return await this.executeTransactionQueryOptimized(txRunner, sql, args);
+			} catch (err) {
+				aborted = true;
+				throw err;
+			}
+		};
+
+		return {
+			provider: this.provider,
+			adapterName: this.adapterName,
+			options: {
+				usePhantomQuery: false,
+			},
+			queryRaw: async (query: SqlQuery) => {
+				const result = await runQuery(query.sql, query.args || []);
+
+				if (!Array.isArray(result) || result.length === 0) {
+					return { columnNames: [], columnTypes: [], rows: [] };
+				}
+
+				const firstRow = result[0];
+				const columnNames = Object.keys(firstRow);
+				const columnCount = columnNames.length;
+
+				const columnTypes = this.determineColumnTypes(result, columnNames);
+				const rows = new Array(result.length);
+
+				for (let rowIndex = 0; rowIndex < result.length; rowIndex++) {
+					const row = result[rowIndex];
+					const processedRow = new Array(columnCount);
+
+					for (let colIndex = 0; colIndex < columnCount; colIndex++) {
+						const val = row[columnNames[colIndex]];
+						processedRow[colIndex] =
+							columnTypes[colIndex] === ColumnTypeEnum.Json
+								? this.ensureJsonString(val)
+								: this.serializeValueFast(val);
+					}
+
+					rows[rowIndex] = processedRow;
+				}
+
+				return { columnNames, columnTypes, rows };
+			},
+			executeRaw: async (query: SqlQuery) => {
+				const result = await runQuery(query.sql, query.args || []);
+				return result.affectedRows || result.count || 0;
+			},
+			commit: async () => {
+				if (aborted) {
+					await finalize("rollback");
+					throw new Error("Transaction rolled back due to a previous error");
+				}
+				await finalize("commit");
+			},
+			rollback: async () => {
+				await finalize("rollback");
+			},
+		};
+	}
+
+	private executeTransactionQueryOptimized(
+		tx: BunSqlTransaction,
+		sql: string,
+		args: any[],
+	): Promise<BunSqlResult> {
+		if (args.length === 0) {
+			const strings = this.createTemplateStrings([sql]);
+			return tx(strings);
+		}
+
+		const cached = this.getOrCreateTemplate(sql, args.length);
+		if (cached) {
+			const expanded = cached.argOrder?.length
+				? cached.argOrder.map((i) => args[i])
+				: args;
+			const coerced = this.coerceArgsForPostgres(expanded);
+			return tx(cached.strings, ...coerced);
+		}
+
+		// Fallback: Transaction query has args but no recognized placeholders
+		// Apply array coercion for Postgres compatibility
+		const coerced = this.coerceArgsForPostgres(args);
+		const strings = this.createTemplateStrings([sql]);
+		return tx(strings, ...coerced);
+	}
+
+	private inferColumnTypeFast(value: unknown): ColumnType {
+		if (value === null || value === undefined) {
+			return ColumnTypeEnum.UnknownNumber;
+		}
+
+		const valueType = typeof value;
+
+		// Fast type checking - most common cases first
+		switch (valueType) {
+			case "boolean":
+				return ColumnTypeEnum.Boolean;
+			case "number":
+				return Number.isInteger(value)
+					? ColumnTypeEnum.Int32
+					: ColumnTypeEnum.Double;
+			case "bigint":
+				return ColumnTypeEnum.Int64;
+			case "string":
+				// Fast string type detection
+				if (DATETIME_REGEX.test(value as string)) {
+					return ColumnTypeEnum.DateTime;
+				}
+				if (DATE_REGEX.test(value as string)) {
+					return ColumnTypeEnum.Date;
+				}
+				if (UUID_REGEX.test(value as string)) {
+					return ColumnTypeEnum.Uuid;
+				}
+				return ColumnTypeEnum.Text;
+			case "object":
+				if (value instanceof Date) {
+					return ColumnTypeEnum.DateTime;
+				}
+				if (Buffer.isBuffer(value)) {
+					return ColumnTypeEnum.Bytes;
+				}
+				return ColumnTypeEnum.Json;
+			default:
+				return ColumnTypeEnum.UnknownNumber;
+		}
+	}
+
+	private serializeValueFast(value: unknown): unknown {
+		if (value === null || value === undefined) {
+			return value;
+		}
+
+		const valueType = typeof value;
+
+		// Fast path for common types
+		if (
+			valueType === "string" ||
+			valueType === "number" ||
+			valueType === "boolean"
+		) {
+			return value;
+		}
+
+		if (valueType === "bigint") {
+			return value.toString();
+		}
+
+		if (value instanceof Date) {
+			return value.toISOString();
+		}
+
+		if (Buffer.isBuffer(value)) {
+			return value;
+		}
+
+		// CRITICAL: If value is an array, return it as-is
+		// Prisma expects arrays for array-typed columns (text[], int[], etc.)
+		// Converting to JSON string breaks Prisma's .map() calls
+		if (Array.isArray(value)) {
+			return value;
+		}
+
+		// Ensure JSON columns arrive as valid JSON strings
+		try {
+			return JSON.stringify(value);
+		} catch {
+			return String(value);
+		}
+	}
+
+	private determineColumnTypes(
+		result: any[],
+		columnNames: string[],
+	): ColumnType[] {
+		const columnCount = columnNames.length;
+		const types = new Array(columnCount) as ColumnType[];
+		for (let i = 0; i < columnCount; i++) {
+			const name = columnNames[i];
+
+			// Check if column contains arrays (must check ALL rows, not just first)
+			let hasArray = false;
+			let hasOtherObjects = false;
+
+			for (let r = 0; r < result.length; r++) {
+				const v = result[r][name];
+				if (v === null || v === undefined) continue;
+
+				if (Array.isArray(v)) {
+					hasArray = true;
+					break; // Found an array, stop checking
+				} else if (
+					typeof v === "object" &&
+					!(v instanceof Date) &&
+					!Buffer.isBuffer(v)
+				) {
+					hasOtherObjects = true;
+				}
+			}
+
+			// If ANY row has an array in this column, it's an array column (NOT JSON)
+			if (hasArray) {
+				// Return a generic type for arrays - let Prisma handle the specifics
+				types[i] = ColumnTypeEnum.UnknownNumber; // Prisma will infer from schema
+			} else if (hasOtherObjects) {
+				// Only non-array objects are JSON
+				types[i] = ColumnTypeEnum.Json;
+			} else {
+				// Fallback to type inference
+				types[i] = this.inferColumnTypeFast(result[0]?.[name]);
+			}
+		}
+		return types;
+	}
+
+	private isJsonishString(s: string): boolean {
+		if (!s) return false;
+		const t = s.trim();
+		if (!t) return false;
+		if (t.startsWith("{") || t.startsWith("[")) return true;
+		if (t.startsWith('"') && t.endsWith('"')) return true;
+		return false;
+	}
+
+	private ensureJsonString(value: unknown): string {
+		if (value === null || value === undefined) return "null";
+		const t = typeof value;
+		if (t === "string") {
+			const s = value as string;
+			return this.isJsonishString(s) ? s : JSON.stringify(s);
+		}
+		if (t === "number" || t === "boolean") return JSON.stringify(value);
+		if (value instanceof Date) return JSON.stringify(value.toISOString());
+		if (Buffer.isBuffer(value))
+			return JSON.stringify(Array.from(value as unknown as Uint8Array));
+		try {
+			return JSON.stringify(value);
+		} catch {
+			return "null";
+		}
+	}
 }
 
 export class BunPostgresAdapter {
-  readonly provider = "postgres" as const;
-  readonly adapterName = "bun-postgres-adapter-optimized";
-  private config: BunPostgresConfig | string;
+	readonly provider = "postgres" as const;
+	readonly adapterName = "bun-postgres-adapter-optimized";
+	private config: BunPostgresConfig | string;
 
-  constructor(config: BunPostgresConfig | string) {
-    this.config = config;
-  }
+	constructor(config: BunPostgresConfig | string) {
+		this.config = config;
+	}
 
-  async connect(): Promise<SqlDriverAdapter> {
-    const connectionString =
-      typeof this.config === "string"
-        ? this.config
-        : this.config.connectionString;
+	async connect(): Promise<SqlDriverAdapter> {
+		const connectionString =
+			typeof this.config === "string"
+				? this.config
+				: this.config.connectionString;
 
-    const maxConnections =
-      typeof this.config === "string"
-        ? 20 // Increased default for better concurrency
-        : this.config.maxConnections || 20;
+		const maxConnections =
+			typeof this.config === "string"
+				? 20 // Increased default for better concurrency
+				: this.config.maxConnections || 20;
 
-    return new OptimizedBunPostgresDriverAdapter(
-      connectionString,
-      maxConnections
-    );
-  }
+		return new OptimizedBunPostgresDriverAdapter(
+			connectionString,
+			maxConnections,
+		);
+	}
 
-  async dispose(): Promise<void> {
-    // Factory cleanup
-  }
+	async dispose(): Promise<void> {
+		// Factory cleanup
+	}
 }
 
 export default BunPostgresAdapter;


### PR DESCRIPTION
Bug fix for incorrect array handling. The arrays were recognized as objects and then handled incorrectly.

All you need to do now is update the version, write the changelog, and, if you want, run your tests again. I couldn't test it because I don't have Docker on my PC.

```
PS D:\Projekte\fallmanagerv1\apps\web> bun run db:seed
$ bun run prisma/seed.ts
🌱 Starting seed...
✅ Organization exists: Default Organization
✅ Organization Settings created
❌ Seed failed: 66 | ${ae(p)}
67 |
68 | If you want the Prisma team to look into it, please open the link above \u{1F64F}
69 | To increase the chance of success, please post your schema and a snippet of
70 | how you used Prisma Client in the issue.
71 | `}function O(e,t){throw new Error(t)}function to(e,t){return e===t||e!==null&&t!==null&&typeof e=="object"&&typeof t=="object"&&Object.keys(e).length===Object.keys(t).length&&Object.keys(e).every(r=>to(e[r],t[r]))}function Ot(e,t){let r=Object.keys(e),n=Object.keys(t);return(r.length<n.length?r:n).every(o=>{if(typeof e[o]==typeof t[o]&&typeof e[o]!="object")return e[o]===t[o];if(ne.isDecimal(e[o])||ne.isDecimal(t[o])){let s=dl(e[o]),a=dl(t[o]);return s&&a&&s.equals(a)}else if(e[o]instanceof Uint8Array||t[o]instanceof Uint8Array){let s=ml(e[o]),a=ml(t[o]);return s&&a&&s.equals(a)}else{if(e[o]instanceof Date||t[o]instanceof Date)return fl(e[o])?.getTime()===fl(t[o])?.getTime();if(typeof e[o]=="bigint"||typeof t[o]=="bigint")return gl(e[o])===gl(t[o]);if(typeof e[o]=="number"||typeof t[o]=="number")return yl(e[o])===yl(t[o])}return to(e[o],t[o])})}function dl(e){return ne.isDecimal(e)?e:typeof e=="number"||typeof e=="string"?new ne(e):void 0}function ml(e){return Buffer.isBuffer(e)?e:e instanceof Uint8Array?Buff | ... truncated 

TypeError: e.map is not a function. (In 'e.map((o, s) => io(o, `${t}[${s}]`, r, n))', 'e.map' is undefined)
 clientVersion: "6.18.0",

      at of (D:\Projekte\fallmanagerv1\apps\web\node_modules\@prisma\client\runtime\client.js:71:8774)
      at El (D:\Projekte\fallmanagerv1\apps\web\node_modules\@prisma\client\runtime\client.js:3:44)
      at interpretNode (D:\Projekte\fallmanagerv1\apps\web\node_modules\@prisma\client\runtime\client.js:3:44)
      at processTicksAndRejections (native:7:39)

error: script "db:seed" exited with code 1
```